### PR TITLE
Ptable cscale range

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -24,7 +24,7 @@
   --zoo-github-corner-bg: var(--text-color);
 
   --sms-options-bg: rgb(20, 18, 36);
-  --sms-max-width: 19em;
+  --sms-max-width: 20em;
   --sms-border: 1px dotted teal;
   --sms-focus-border: 1px dotted cornflowerblue;
   --sms-active-color: cornflowerblue;

--- a/src/lib/ElementScatter.svelte
+++ b/src/lib/ElementScatter.svelte
@@ -4,15 +4,14 @@
   import { pretty_num } from './labels'
   import { active_element } from './stores'
 
-  // either array of length 118 (one heat value for each element) or object with
-  // element symbol as key and heat value as value
+  // either array of length 118 (one heat value for each element) or
+  // object with element symbol as key and heat value as value
   export let y: number[]
   export let x_label = `Atomic Number`
   export let y_label: string = ``
   export let y_unit: string = ``
-
-  let tooltip_point: Coords
-  let hovered = false
+  export let tooltip_point: Coords
+  export let hovered: boolean = false
 
   // update tooltip on hover element tile
   $: if ($active_element?.number && !hovered) {
@@ -23,6 +22,8 @@
   }
 </script>
 
+<!-- set max-height to ensure ScatterPlot is never taller than 3 Ptable rows
+  so it doesn't stretch the table. assumes Ptable has 18 rows -->
 <ScatterPlot
   {y}
   x={[...Array(y.length + 1).keys()].slice(1)}
@@ -31,11 +32,14 @@
   {x_label}
   on:change
   {...$$props}
+  style="max-height: calc(100cqw / 18 * 3);"
 >
   <div slot="tooltip" let:x let:y>
-    <strong>{x} - {element_data[x - 1]?.name}</strong>
-    <br />{y_label} = {pretty_num(y)}
-    {y_unit ?? ``}
+    {#if $active_element}
+      <strong>{x} - {element_data[x - 1]?.name}</strong>
+      <br />{y_label} = {pretty_num(y)}
+      {y_unit ?? ``}
+    {/if}
   </div>
 </ScatterPlot>
 
@@ -46,5 +50,6 @@
     width: max-content;
     box-sizing: border-box;
     border-radius: 3pt;
+    font-size: 2.3cqw;
   }
 </style>

--- a/src/lib/ScatterPlot.svelte
+++ b/src/lib/ScatterPlot.svelte
@@ -138,6 +138,8 @@
     height: 100%;
     display: flex;
     min-height: var(--svt-min-height, 100px);
+    container-type: inline-size;
+    z-index: 1; /* ensure tooltip renders above ElementTiles */
   }
   svg {
     width: 100%;
@@ -145,9 +147,7 @@
     font-weight: lighter;
     overflow: visible;
     z-index: 1;
-  }
-  g.tick {
-    font-size: clamp(10pt, 1vw, 15pt);
+    font-size: 2.3cqw;
   }
   line {
     stroke: gray;
@@ -156,9 +156,7 @@
   }
   g.x-axis text {
     text-anchor: middle;
-  }
-  g.x-axis text {
-    dominant-baseline: hanging;
+    dominant-baseline: top;
   }
   g.y-axis text {
     dominant-baseline: central;
@@ -168,6 +166,5 @@
   }
   text.label {
     text-anchor: middle;
-    font-size: clamp(11pt, 1.2vw, 16pt);
   }
 </style>

--- a/src/lib/TableInset.svelte
+++ b/src/lib/TableInset.svelte
@@ -1,16 +1,18 @@
 <script lang="ts">
-  export let grid_col = `3 / span 10`
-  export let grid_row = `1 / span 3`
   export let style: string | null = null
+  export let tag: string = `aside` // styles below don't apply if tag is not aside or div
 </script>
 
-<aside style:grid-column={grid_col} style:grid-row={grid_row} {style}>
+<svelte:element this={tag} {style}>
   <slot />
-</aside>
+</svelte:element>
 
 <style>
-  aside {
+  aside,
+  div {
     display: grid;
     box-sizing: border-box;
+    grid-row: 1 / span 3;
+    grid-column: 3 / span 10;
   }
 </style>

--- a/src/routes/(demos)/color-scales/+page.svx
+++ b/src/routes/(demos)/color-scales/+page.svx
@@ -1,32 +1,32 @@
-## Materials Project Element Heatmap
-
 ```svelte example stackblitz
 <script>
-  import { PeriodicTable, TableInset, ColorScaleSelect } from '$lib'
+  import { PeriodicTable, TableInset, ColorBar, ColorScaleSelect } from '$lib'
   import { pretty_num } from '$lib/labels'
   import Multiselect from 'svelte-multiselect'
   import { RadioButtons, Toggle } from 'svelte-zoo'
   import mp_elem_counts from './mp-element-counts.json'
   import wbm_elem_counts from './wbm-element-counts.json'
+  import { extent } from 'd3-array'
 
   let log = true // log color scale
   let data = `MP`
-  let color_scale
-  $: heatmap_values = data == `WBM` ? wbm_elem_counts : mp_elem_counts
-  $: total = Object.values(heatmap_values).reduce((a, b) => a + b, 0)
+  let color_scale = 'Viridis'
+  $: heatmap_values = Object.values(data == `WBM` ? wbm_elem_counts : mp_elem_counts)
+  $: total = heatmap_values.reduce((a, b) => a + b, 0)
 </script>
 
+<h2>{data == 'MP' ? 'Materials Project' : 'WBM'} Element Heatmap</h2>
 
 <section>
   <span>Data set &ensp; <RadioButtons options={[`MP`, `WBM`]} bind:selected={data} /></span>
 
   <span>Log color scale <Toggle bind:checked={log} /></span>
 
-  <ColorScaleSelect bind:value={color_scale} selected={['Viridis']} />
+  <ColorScaleSelect bind:value={color_scale} selected={[color_scale]} />
 </section>
 
 <PeriodicTable {heatmap_values} {log} {color_scale}>
-  <TableInset slot="inset" grid_row="3" let:active_element>
+  <TableInset slot="inset" style="grid-row: 3;" let:active_element>
     {#if active_element?.name}
       <strong>
         {active_element?.name}: {pretty_num(mp_elem_counts[active_element?.symbol])}
@@ -38,6 +38,8 @@
     {/if}
   </TableInset>
 </PeriodicTable>
+
+<ColorBar range={extent(heatmap_values)} {color_scale} tick_labels={5} style="width: 100%; margin: 2em 1em;" />
 
 <style>
   section {
@@ -57,10 +59,3 @@
   }
 </style>
 ```
-
-<!-- TODO remove once svelte-zoo update makes this unnecessary -->
-<style>
-  :global(.zoo-radio-btn) {
-    display: inline-flex !important;
-  }
-</style>


### PR DESCRIPTION
 0efa39b use `cqw` font sizes in `ScatterPlot` for better scaling with plot size
 47173f7 add prop `color_scale_range` to `PeriodicTable`
 2adefeb make `TableInset` wrapper `<svelte:element>`
 f378122 add `<ColorBar>` to `src/routes/(demos)/color-scales/+page.svx`