### PR TITLE
Fix structure controls for `atom_radius`, `same_size_atoms`

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,21 +1,15 @@
-root: true
 env:
   browser: true
-  es2020: true
   node: true
-parser: '@typescript-eslint/parser'
-parserOptions:
-  sourceType: module
-  ecmaVersion: latest
-plugins: [svelte3, '@typescript-eslint']
 extends:
+  - plugin:svelte/recommended
   - eslint:recommended
   - plugin:@typescript-eslint/recommended
 overrides:
   - files: ['*.svelte']
-    processor: svelte3/svelte3
-settings:
-  svelte3/typescript: true
+    parser: svelte-eslint-parser
+    parserOptions:
+      parser: '@typescript-eslint/parser'
 rules:
   indent: [error, 2, SwitchCase: 1]
   '@typescript-eslint/quotes': [error, backtick, avoidEscape: true]
@@ -23,6 +17,9 @@ rules:
   linebreak-style: [error, unix]
   no-console: [error, allow: [warn, error]]
   no-var: error
-  # allow triple slash for typescript file referencing https://git.io/JCeqO
-  spaced-comment: [error, always, { markers: [/] }]
   '@typescript-eslint/no-inferrable-types': off
+  '@typescript-eslint/no-unused-vars':
+    [error, { argsIgnorePattern: ^_, varsIgnorePattern: ^_ }]
+  svelte/no-at-html-tags: off
+  no-inner-declarations: off
+ignorePatterns: [build/, dist/]

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,5 +10,3 @@ on:
 jobs:
   build:
     uses: janosh/workflows/.github/workflows/nodejs-gh-pages.yml@main
-    with:
-      install-cmd: npm install --force

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,5 +12,3 @@ on:
 jobs:
   tests:
     uses: janosh/workflows/.github/workflows/npm-test-release.yml@main
-    with:
-      install-cmd: npm install --force

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,18 +30,20 @@ repos:
         exclude: ^changelog.md|.*/structures/.*\.json$
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.41.0
+    rev: v8.43.0
     hooks:
       - id: eslint
         types: [file]
-        args: [--fix, --plugin, 'svelte3, @typescript-eslint']
+        args: [--fix]
         files: \.(js|ts|svelte)$
         additional_dependencies:
           - eslint
+          - svelte
           - typescript
-          - eslint-plugin-svelte3
+          - eslint-plugin-svelte
           - '@typescript-eslint/eslint-plugin'
           - '@typescript-eslint/parser'
+          - svelte-eslint-parser
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.4

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@typescript-eslint/parser": "^5.60.1",
     "@vitest/coverage-c8": "^0.32.2",
     "eslint": "^8.43.0",
-    "eslint-plugin-svelte3": "^4.0.0",
+    "eslint-plugin-svelte": "^2.32.2",
     "hastscript": "^7.2.0",
     "jsdom": "^22.1.0",
     "mdsvex": "^0.11.0",

--- a/src/lib/BohrAtom.svelte
+++ b/src/lib/BohrAtom.svelte
@@ -18,8 +18,6 @@
   // Bohr atom electron orbital period is given by
   // T = (n^3 h^3) / (4pi^2 m K e^4 Z^2) = 1.52 * 10^-16 * n^3 / Z^2 s
   // with n the shell number, Z the atomic number, m the mass of the electron
-  $: Z = shells.reduce((a, b) => a + b, 0)
-
   $: _nucleus_props = {
     r: 20,
     fill: `white`,

--- a/src/lib/InfoCard.svelte
+++ b/src/lib/InfoCard.svelte
@@ -24,14 +24,14 @@
       </slot>
     </h2>
   {/if}
-  {#each data as { title, value, unit = '', fmt = default_fmt }}
+  {#each data as { title, value, unit, fmt = default_fmt }}
     <div>
       <span class="title" {title}>
         {@html title}
       </span>
       <strong>
         {@html typeof value == `number` ? pretty_num(value, fmt) : value}
-        {unit}
+        {unit ?? ``}
       </strong>
     </div>
   {:else}

--- a/src/lib/element/ElementTile.svelte
+++ b/src/lib/element/ElementTile.svelte
@@ -21,6 +21,7 @@
   export let node: HTMLElement | null = null
   export let label: string | null = null
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   type $$Events = PeriodicTableEvents // for type-safe event listening on this component
 
   $: category = element.category.replaceAll(` `, `-`)
@@ -36,7 +37,7 @@
 </script>
 
 <svelte:element
-  this={href ? 'a' : 'div'}
+  this={href ? `a` : `div`}
   bind:this={node}
   {href}
   data-sveltekit-noscroll

--- a/src/lib/periodic-table/PeriodicTable.svelte
+++ b/src/lib/periodic-table/PeriodicTable.svelte
@@ -53,6 +53,7 @@
   export let color_overrides: Record<ElementSymbol, string> = {}
   export let labels: Record<ElementSymbol, string> = {}
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   type $$Events = PeriodicTableEvents // for type-safe event listening on this component
 
   let heat_values: number[] = []

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -27,6 +27,8 @@
   export let camera_position: [number, number, number] = [10, 10, 10]
   // zoom level of the camera
   export let initial_zoom: number | undefined = undefined
+  // auto rotate speed. set to 0 to disable auto rotation.
+  export let auto_rotate: number = 0
   // zoom speed. set to 0 to disable zooming.
   export let zoom_speed: number = 0.3
   // pan speed. set to 0 to disable panning.
@@ -235,6 +237,11 @@
       <hr />
 
       <label>
+        Auto rotate speed
+        <input type="number" min={0} max={2} step={0.01} bind:value={auto_rotate} />
+        <input type="range" min={0} max={2} step={0.01} bind:value={auto_rotate} />
+      </label>
+      <label>
         Zoom speed
         <input type="number" min={0} max={2} step={0.01} bind:value={zoom_speed} />
         <input type="range" min={0} max={2} step={0.01} bind:value={zoom_speed} />
@@ -267,14 +274,15 @@
         {show_atoms}
         {show_bonds}
         {show_cell}
+        {show_vectors}
         {...$$restProps}
-        {pan_speed}
         {cell_opacity}
         {cell_line_width}
         {bond_radius}
         {camera_position}
+        {auto_rotate}
+        {pan_speed}
         {zoom_speed}
-        {show_vectors}
         bind:atom_radius
         bind:same_size_atoms
       >

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -46,14 +46,14 @@
   // the button to toggle the control panel
   export let toggle_controls_btn: HTMLButtonElement | undefined = undefined
   // cell opacity
-  export let cell_opacity: number | undefined = undefined
+  export let cell_opacity: number | undefined = 0.15
   // whether to show the lattice vectors
   export let show_vectors: boolean = true
   // bindable width of the canvas
   export let width: number = 0
   // bindable height of the canvas
   export let height: number = 0
-  export let reset_text: string = `Reset view`
+  // export let reset_text: string = `Reset view`
   export let color_scheme: 'Jmol' | 'Vesta' = `Vesta`
   export let hovered: boolean = false
   export let dragover: boolean = false
@@ -140,12 +140,12 @@
   >
     <section class:visible={visible_buttons}>
       <!-- TODO show only when camera was moved -->
-      <button
+      <!-- <button
         class="reset-camera"
         on:click={() => {
           // TODO implement reset view and controls
         }}>{reset_text}</button
-      >
+      > -->
       <button
         on:click={() => (controls_open = !controls_open)}
         bind:this={toggle_controls_btn}
@@ -164,15 +164,19 @@
       {/if}
     </section>
 
-    <dialog bind:this={controls} open={controls_open}>
+    <dialog class="controls" bind:this={controls} open={controls_open}>
       <label>
         Atom radius
+        <small> (Å)</small>
+        <input type="number" min="0.1" max="1" step="0.05" bind:value={atom_radius} />
         <input type="range" min="0.1" max="1" step="0.05" bind:value={atom_radius} />
       </label>
       <label>
         <input type="checkbox" bind:checked={same_size_atoms} />
-        Scale according to atomic radii
-        <small> (if false, all atoms have same size)</small>
+        <span>
+          Scale sites according to atomic radii
+          <small> (if false, all atoms have same size)</small>
+        </span>
       </label>
       <label>
         <input type="checkbox" bind:checked={atom_labels} />
@@ -189,6 +193,7 @@
       {#if show_cell}
         <label>
           Unit cell opacity
+          <input type="number" min="0" max="1" step="0.05" bind:value={cell_opacity} />
           <input type="range" min="0" max="1" step="0.05" bind:value={cell_opacity} />
         </label>
       {/if}
@@ -198,12 +203,14 @@
       </label>
       <label>
         Zoom speed
+        <input type="number" min="0" max="2" step="0.01" bind:value={zoom_speed} />
         <input type="range" min="0" max="2" step="0.01" bind:value={zoom_speed} />
       </label>
       <label>
         <Tooltip text="pan by clicking and dragging while holding cmd, ctrl or shift">
           Pan speed
         </Tooltip>
+        <input type="number" min="0" max="2" step="0.01" bind:value={pan_speed} />
         <input type="range" min="0" max="2" step="0.01" bind:value={pan_speed} />
       </label>
       <!-- color scheme -->
@@ -231,12 +238,13 @@
         {zoom_speed}
         {show_cell}
         {show_vectors}
+        bind:atom_radius
+        bind:same_size_atoms
       >
         <!-- above let:elem needed to fix false positive eslint no-undef -->
-        <slot slot="atom-label" let:elem>
+        <slot slot="atom-label" name="atom-label" let:elem>
           {#if atom_labels}
             <span class="atom-label" style={atom_labels_style}>
-              <!-- eslint-ignore-next-line no-undef -->
               {atom_labels === true ? elem : atom_labels[elem]}
             </span>
           {/if}
@@ -304,7 +312,7 @@
     gap: 1ex;
   }
 
-  dialog {
+  dialog.controls {
     position: absolute;
     left: unset;
     background: transparent;
@@ -322,14 +330,33 @@
     background-color: var(--controls-bg, rgba(0, 0, 0, 0.7));
     padding: var(--controls-padding, 6pt 9pt);
     border-radius: var(--controls-border-radius, 3pt);
-    width: var(--controls-width, 18em);
+    width: var(--controls-width, 20em);
     max-width: var(--controls-max-width, 90cqw);
   }
-  dialog[open] {
+  dialog.controls label {
+    display: flex;
+    align-items: center;
+    gap: 4pt;
+  }
+  dialog.controls input[type='range'] {
+    margin-left: auto;
+  }
+  dialog.controls input[type='number'] {
+    background-color: rgba(255, 255, 255, 0.15);
+    width: 2em;
+    text-align: center;
+    border-radius: 3pt;
+    border: none;
+  }
+  input::-webkit-inner-spin-button {
+    display: none;
+  }
+
+  dialog.controls[open] {
     visibility: visible;
     opacity: 1;
   }
-  dialog button {
+  dialog.controls button {
     width: max-content;
     background-color: rgba(255, 255, 255, 0.4);
   }

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -231,7 +231,6 @@
         {zoom_speed}
         {show_cell}
         {show_vectors}
-        let:elem
       >
         <!-- above let:elem needed to fix false positive eslint no-undef -->
         <slot slot="atom-label" let:elem>

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -252,29 +252,11 @@
       </StructureScene>
     </Canvas>
 
-    <StructureLegend elements={get_elem_amounts(structure)} />
+    <StructureLegend elements={get_elem_amounts(structure)} bind:tips_modal />
 
     <div class="bottom-left">
       <slot name="bottom-left" {structure} />
     </div>
-
-    {#if enable_tips}
-      <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
-      <dialog
-        bind:this={tips_modal}
-        on:click={tips_modal?.close}
-        on:keydown={tips_modal?.close}
-        role="tooltip"
-      >
-        <slot name="tips-modal">
-          <p>Drop a JSON file onto the canvas to load a new structure.</p>
-          <p>
-            Click on an atom to make it active. Then hover another atom to get its
-            distance to the active atom.
-          </p>
-        </slot>
-      </dialog>
-    {/if}
   </div>
 {:else if structure}
   <p class="warn">No sites found in structure</p>
@@ -369,24 +351,6 @@
   p.warn {
     font-size: larger;
     text-align: center;
-  }
-  dialog[role='tooltip'] {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    margin: 0;
-    padding: 4pt 1em;
-    background-color: rgb(25, 25, 25);
-    color: white;
-    border-radius: 5px;
-    transition: all 0.3s;
-  }
-  dialog[role='tooltip']::backdrop {
-    background: rgba(0, 0, 0, 0.4);
-  }
-  dialog[role='tooltip'] p {
-    margin: 0;
   }
   .atom-label {
     background: rgba(0, 0, 0, 0.4);

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -40,13 +40,16 @@
   // TODO whether to make the canvas fill the whole screen
   // export let fullscreen: boolean = false
   // whether to show the structure's lattice cell as a wireframe
+  export let show_atoms: boolean = true
+  export let show_bonds: boolean = true
+  export let bond_thickness: number | undefined = undefined
   export let show_cell: 'surface' | 'wireframe' | null = `wireframe`
+  export let cell_opacity: number | undefined = 0.15
+  export let cell_line_width: number = 1
   // the control panel DOM element
   export let controls: HTMLElement | undefined = undefined
   // the button to toggle the control panel
   export let toggle_controls_btn: HTMLButtonElement | undefined = undefined
-  // cell opacity
-  export let cell_opacity: number | undefined = 0.15
   // whether to show the lattice vectors
   export let show_vectors: boolean = true
   // bindable width of the canvas
@@ -165,6 +168,31 @@
     </section>
 
     <dialog class="controls" bind:this={controls} open={controls_open}>
+      <div style="display: flex; align-items: center; gap: 4pt; flex-wrap: wrap;">
+        Show <label>
+          <input type="checkbox" bind:checked={show_atoms} />
+          atoms
+        </label>
+        <label>
+          <input type="checkbox" bind:checked={show_bonds} />
+          bonds
+        </label>
+        <label>
+          <input type="checkbox" bind:checked={show_vectors} />
+          lattice vectors
+        </label>
+      </div>
+      <label>
+        Show unit cell as
+        <select bind:value={show_cell}>
+          <option value="surface">surface</option>
+          <option value="wireframe">wireframe</option>
+          <option value={null}>none</option>
+        </select>
+      </label>
+
+      <hr />
+
       <label>
         Atom radius
         <small> (Å)</small>
@@ -179,16 +207,16 @@
         </span>
       </label>
       <label>
+        Bond thickness
+        <input type="number" min="0.1" max="3" step="0.1" bind:value={bond_thickness} />
+        <input type="range" min="0.1" max="3" step="0.1" bind:value={bond_thickness} />
+      </label>
+
+      <hr />
+
+      <label>
         <input type="checkbox" bind:checked={atom_labels} />
         Show atom labels
-      </label>
-      <label>
-        Show unit cell as
-        <select bind:value={show_cell}>
-          <option value="surface">surface</option>
-          <option value="wireframe">wireframe</option>
-          <option value={null}>none</option>
-        </select>
       </label>
       {#if show_cell}
         <label>
@@ -197,10 +225,9 @@
           <input type="range" min="0" max="1" step="0.05" bind:value={cell_opacity} />
         </label>
       {/if}
-      <label>
-        <input type="checkbox" bind:checked={show_vectors} />
-        Show lattice vectors
-      </label>
+
+      <hr />
+
       <label>
         Zoom speed
         <input type="number" min="0" max="2" step="0.01" bind:value={zoom_speed} />
@@ -231,12 +258,15 @@
     <Canvas>
       <StructureScene
         structure={symmetrize_structure(structure)}
+        {show_atoms}
+        {show_bonds}
+        {show_cell}
         {...$$restProps}
         {pan_speed}
         {cell_opacity}
+        {cell_line_width}
         {camera_position}
         {zoom_speed}
-        {show_cell}
         {show_vectors}
         bind:atom_radius
         bind:same_size_atoms
@@ -314,6 +344,13 @@
     border-radius: var(--controls-border-radius, 3pt);
     width: var(--controls-width, 20em);
     max-width: var(--controls-max-width, 90cqw);
+  }
+  dialog.controls hr {
+    width: 100%;
+    height: 0.5px;
+    border: none;
+    background: gray;
+    margin: 0;
   }
   dialog.controls label {
     display: flex;

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -42,7 +42,7 @@
   // whether to show the structure's lattice cell as a wireframe
   export let show_atoms: boolean = true
   export let show_bonds: boolean = true
-  export let bond_thickness: number | undefined = undefined
+  export let bond_radius: number | undefined = undefined
   export let show_cell: 'surface' | 'wireframe' | null = `wireframe`
   export let cell_opacity: number | undefined = 0.15
   export let cell_line_width: number = 1
@@ -196,8 +196,8 @@
       <label>
         Atom radius
         <small> (Å)</small>
-        <input type="number" min="0.1" max="1" step="0.05" bind:value={atom_radius} />
-        <input type="range" min="0.1" max="1" step="0.05" bind:value={atom_radius} />
+        <input type="number" min="0.1" max={1} step={0.05} bind:value={atom_radius} />
+        <input type="range" min="0.1" max={1} step={0.05} bind:value={atom_radius} />
       </label>
       <label>
         <input type="checkbox" bind:checked={same_size_atoms} />
@@ -207,9 +207,15 @@
         </span>
       </label>
       <label>
-        Bond thickness
-        <input type="number" min="0.1" max="3" step="0.1" bind:value={bond_thickness} />
-        <input type="range" min="0.1" max="3" step="0.1" bind:value={bond_thickness} />
+        Bond radius
+        <input
+          type="number"
+          min={0.001}
+          max={0.1}
+          step={0.001}
+          bind:value={bond_radius}
+        />
+        <input type="range" min="0.001" max="0.1" step={0.001} bind:value={bond_radius} />
       </label>
 
       <hr />
@@ -221,8 +227,8 @@
       {#if show_cell}
         <label>
           Unit cell opacity
-          <input type="number" min="0" max="1" step="0.05" bind:value={cell_opacity} />
-          <input type="range" min="0" max="1" step="0.05" bind:value={cell_opacity} />
+          <input type="number" min={0} max={1} step={0.05} bind:value={cell_opacity} />
+          <input type="range" min={0} max={1} step={0.05} bind:value={cell_opacity} />
         </label>
       {/if}
 
@@ -230,15 +236,15 @@
 
       <label>
         Zoom speed
-        <input type="number" min="0" max="2" step="0.01" bind:value={zoom_speed} />
-        <input type="range" min="0" max="2" step="0.01" bind:value={zoom_speed} />
+        <input type="number" min={0} max={2} step={0.01} bind:value={zoom_speed} />
+        <input type="range" min={0} max={2} step={0.01} bind:value={zoom_speed} />
       </label>
       <label>
         <Tooltip text="pan by clicking and dragging while holding cmd, ctrl or shift">
           Pan speed
         </Tooltip>
-        <input type="number" min="0" max="2" step="0.01" bind:value={pan_speed} />
-        <input type="range" min="0" max="2" step="0.01" bind:value={pan_speed} />
+        <input type="number" min={0} max={2} step={0.01} bind:value={pan_speed} />
+        <input type="range" min={0} max={2} step={0.01} bind:value={pan_speed} />
       </label>
       <!-- color scheme -->
       <label>
@@ -265,6 +271,7 @@
         {pan_speed}
         {cell_opacity}
         {cell_line_width}
+        {bond_radius}
         {camera_position}
         {zoom_speed}
         {show_vectors}

--- a/src/lib/structure/StructureLegend.svelte
+++ b/src/lib/structure/StructureLegend.svelte
@@ -8,6 +8,7 @@
   export let elements: Composition
   export let elem_color_picker_title: string = `Double click to reset color`
   export let labels: HTMLLabelElement[] = []
+  export let tips_modal: HTMLDialogElement | undefined = undefined
   export let style: string | null = null
 </script>
 
@@ -36,6 +37,22 @@
   {/each}
 </div>
 
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+<dialog
+  bind:this={tips_modal}
+  on:click={tips_modal?.close}
+  on:keydown={tips_modal?.close}
+  role="tooltip"
+>
+  <slot name="tips-modal">
+    <p>Drop a JSON file onto the canvas to load a new structure.</p>
+    <p>
+      Click on an atom to make it active. Then hover another atom to get its distance to
+      the active atom.
+    </p>
+  </slot>
+</dialog>
+
 <style>
   div {
     display: flex;
@@ -58,5 +75,42 @@
     top: 0;
     left: 0;
     cursor: pointer;
+  }
+  dialog[role='tooltip'] {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    margin: 0;
+    padding: 4pt 1em;
+    background-color: rgba(0, 0, 0, 0.8);
+    color: white;
+    border-radius: 5px;
+    transition: all 0.3s;
+    overflow: visible;
+  }
+  /* info icon in top left corner */
+  dialog[role='tooltip']::before {
+    content: '?';
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform: translate(-50%, -50%);
+    font-size: 20pt;
+    color: white;
+    background-color: rgba(0, 0, 0, 0.8);
+    border-radius: 50%;
+    width: 1em;
+    height: 1em;
+    line-height: 1em;
+    text-align: center;
+    border: 1px solid white;
+    box-sizing: border-box;
+  }
+  dialog[role='tooltip']::backdrop {
+    background: rgba(0, 0, 0, 0.2);
+  }
+  dialog[role='tooltip'] p {
+    margin: 0;
   }
 </style>

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -31,6 +31,8 @@
   // TODO whether to make the canvas fill the whole screen
   // export let fullscreen: boolean = false
   // whether to show the structure's lattice cell as a wireframe
+  export let show_atoms: boolean = true
+  export let show_bonds: boolean = true
   export let show_cell: 'surface' | 'wireframe' | null = `wireframe`
   // thickness of the wireframe lines that indicate the lattice's unit cell
   // due to limitations of OpenGL with WebGL renderer, on most platforms linewidth will be 1 regardless of set value
@@ -94,7 +96,7 @@
 <T.DirectionalLight position={[3, 10, 10]} intensity={0.6} />
 <T.AmbientLight intensity={0.3} />
 
-{#if structure?.sites}
+{#if show_atoms && structure?.sites}
   <InstancedMesh>
     <T.MeshStandardMaterial />
     <T.SphereGeometry args={[1, 20, 20]} />
@@ -121,13 +123,15 @@
   </InstancedMesh>
 {/if}
 
-<InstancedMesh>
-  <T.CylinderGeometry args={[bond_thickness, bond_thickness, 1, 16]} />
-  <T.MeshStandardMaterial opacity={bond_opacity} color={bond_color} />
-  {#each bond_pairs ?? [] as [from, to]}
-    <Bond {from} {to} radius={1} />
-  {/each}
-</InstancedMesh>
+{#if show_bonds}
+  <InstancedMesh>
+    <T.CylinderGeometry args={[bond_thickness, bond_thickness, 1, 16]} />
+    <T.MeshStandardMaterial opacity={bond_opacity} color={bond_color} />
+    {#each bond_pairs ?? [] as [from, to]}
+      <Bond {from} {to} radius={1} />
+    {/each}
+  </InstancedMesh>
+{/if}
 
 <!-- highlight active and hovered sites -->
 {#each [{ site: hovered_site, opacity: 0.2 }, { site: active_site, opacity: 0.3 }] as { site, opacity }}


### PR DESCRIPTION
13c0d10 eslint-plugin-svelte3 to eslint-plugin-svelte migration (last Svelte 3 dep)
3a61f18 fix eslint errors
9f3a266 fix structure controls atom_radius, same_size_atoms
ea4b7f0 move structure tips_modal to StructureLegend

TODO: "Show atom labels" toggle still broken