### PR TITLE
`ScatterPlot` support custom x/y tick label spacing and formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "update-coverage": "vitest tests/unit --run --coverage && npx istanbul-badges-readme"
   },
   "dependencies": {
-    "@sveltejs/kit": "^2.20.2",
+    "@sveltejs/kit": "^2.20.3",
     "@threlte/core": "8.0.1",
     "@threlte/extras": "^9.1.0",
     "d3": "^7.9.0",
@@ -35,10 +35,10 @@
     "d3-scale-chromatic": "^3.1.0",
     "d3-shape": "^3.2.0",
     "highlight.js": "^11.11.1",
-    "svelte": "5.25.3",
+    "svelte": "5.25.6",
     "svelte-multiselect": "11.0.0-rc.1",
     "svelte-zoo": "^0.4.17",
-    "three": "^0.174.0"
+    "three": "^0.175.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.51.1",
@@ -54,11 +54,12 @@
     "@types/d3-scale-chromatic": "^3.1.0",
     "@types/d3-shape": "^3.1.7",
     "@types/d3-time-format": "^4.0.3",
-    "@types/three": "^0.174.0",
-    "@vitest/coverage-v8": "^3.0.9",
+    "@types/three": "^0.175.0",
+    "@vitest/coverage-v8": "^3.1.1",
     "d3-time-format": "^4.1.0",
     "eslint": "^9.23.0",
-    "eslint-plugin-svelte": "^3.3.3",
+    "eslint-plugin-svelte": "^3.5.0",
+    "happy-dom": "^17.4.4",
     "hastscript": "^9.0.1",
     "iconify-icon": "^2.3.0",
     "jsdom": "^26.0.0",
@@ -76,9 +77,9 @@
     "svelte-toc": "^0.5.9",
     "svelte2tsx": "^0.7.35",
     "typescript": "5.8.2",
-    "typescript-eslint": "^8.28.0",
-    "vite": "^6.2.3",
-    "vitest": "^3.0.9"
+    "typescript-eslint": "^8.29.0",
+    "vite": "^6.2.5",
+    "vitest": "^3.1.1"
   },
   "keywords": [
     "svelte",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "happy-dom": "^17.4.4",
     "hastscript": "^9.0.1",
     "iconify-icon": "^2.3.0",
-    "jsdom": "^26.0.0",
     "mdsvex": "^0.12.3",
     "mdsvexamples": "^0.5.0",
     "prettier": "^3.5.3",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,7 +3,7 @@ export const mp_build_bucket = `https://materialsproject-build.s3.amazonaws.com/
 export async function decompress(blob: ReadableStream<Uint8Array> | null) {
   // @ts-expect-error - TS doesn't know about DecompressionStream yet
   const unzip = new DecompressionStream(`gzip`)
-  const stream = blob.pipeThrough(unzip)
+  const stream = blob?.pipeThrough(unzip)
   return await new Response(stream).text()
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -33,6 +33,5 @@ export function download(data: string | Blob, filename: string, type: string) {
   document.body.appendChild(link)
   link.click()
   link.remove()
-  // raises 'is not a function' error in JSDOM
-  // URL.revokeObjectURL(url)
+  URL.revokeObjectURL(url)
 }

--- a/src/lib/plot/ColorBar.svelte
+++ b/src/lib/plot/ColorBar.svelte
@@ -75,7 +75,7 @@
         )
         return d3sc.interpolateViridis
       }
-    }
+    } else return color_scale
   })
 
   let grad_dir = $derived({ horizontal: `to right`, vertical: `to bottom` }[orientation])

--- a/src/routes/(demos)/scatter-plot/+page.md
+++ b/src/routes/(demos)/scatter-plot/+page.md
@@ -339,3 +339,69 @@ This example combines various features of the ScatterPlot component:
   `}
 />
 ```
+
+## Points with Shared Coordinates
+
+This example demonstrates how points that share the same X or Y coordinates can still be individually hovered:
+
+```svelte example stackblitz
+<script>
+  import { ScatterPlot } from '$lib'
+
+  // Create points with shared X or Y coordinates
+  const shared_coords_data = {
+    // Points with same X values (vertical line)
+    x: [5, 5, 5, 5, 5,
+    // Points with same Y values (horizontal line)
+       1, 2, 3, 4, 5,
+    // Some random points
+       7, 8, 9, 7, 9],
+    y: [1, 2, 3, 4, 5,
+       3, 3, 3, 3, 3,
+       1, 2, 3, 4, 5],
+    point_style: { fill: 'steelblue', radius: 6 },
+    // Add distinct metadata for each point to identify them
+    metadata: [
+      // Vertical line points
+      {id: 'v1', label: 'V1 (5,1)'}, {id: 'v2', label: 'V2 (5,2)'},
+      {id: 'v3', label: 'V3 (5,3)'}, {id: 'v4', label: 'V4 (5,4)'},
+      {id: 'v5', label: 'V5 (5,5)'},
+      // Horizontal line points
+      {id: 'h1', label: 'H1 (1,3)'}, {id: 'h2', label: 'H2 (2,3)'},
+      {id: 'h3', label: 'H3 (3,3)'}, {id: 'h4', label: 'H4 (4,3)'},
+      {id: 'h5', label: 'H5 (5,3)'},
+      // Random points
+      {id: 'r1', label: 'R1 (7,1)'}, {id: 'r2', label: 'R2 (8,2)'},
+      {id: 'r3', label: 'R3 (9,3)'}, {id: 'r4', label: 'R4 (7,4)'},
+      {id: 'r5', label: 'R5 (9,5)'}
+    ]
+  }
+
+  let hovered_point = null;
+</script>
+
+<ScatterPlot
+  series={[shared_coords_data]}
+  x_lim={[0, 10]}
+  y_lim={[0, 6]}
+  x_ticks={1}
+  y_ticks={1}
+  x_label="X Axis"
+  y_label="Y Axis"
+  change={(event) => (hovered_point = event)}
+  tooltip={({ x, y, metadata }) => `
+    <div style="background: rgba(0,0,0,0.8); color: white; padding: 0.5em; border-radius: 4px; max-width: 200px;">
+      <strong>${metadata?.label || 'Point'}</strong><br />
+      Coordinates: (${x}, ${y})<br />
+      ID: ${metadata?.id || 'unknown'}
+    </div>
+  `}
+  style="height: 350px; width: 100%;"
+/>
+
+{#if hovered_point}
+  <div style="margin-top: 1em; padding: 0.5em; border: 1px solid #ccc; border-radius: 4px;">
+    <strong>Currently hovering:</strong> {hovered_point.metadata?.label || 'Unknown point'} at ({hovered_point.x}, {hovered_point.y})
+  </div>
+{/if}
+```

--- a/src/routes/(demos)/scatter-plot/+page.md
+++ b/src/routes/(demos)/scatter-plot/+page.md
@@ -1,0 +1,341 @@
+`ScatterPlot.svelte`
+
+The `ScatterPlot` component allows you to create interactive scatter plots with various features and configurations.
+
+## Basic Scatter Plot
+
+A simple scatter plot with default settings:
+
+```svelte example stackblitz
+<script>
+  import { ScatterPlot } from '$lib'
+
+  // Basic single series data
+  const basic_data = {
+    x: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    y: [5, 7, 2, 8, 4, 9, 3, 6, 8, 5],
+    point_style: { fill: 'steelblue', radius: 5 }
+  }
+</script>
+
+<ScatterPlot
+  series={[basic_data]}
+  x_label="X Axis"
+  y_label="Y Value"
+  style="height: 300px; width: 100%;"
+/>
+```
+
+## Multiple Series
+
+Displaying multiple data series with different styling:
+
+```svelte example stackblitz
+<script>
+  import { ScatterPlot } from '$lib'
+
+  // Multiple series data
+  const series_a = {
+    x: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    y: [5, 7, 2, 8, 4, 9, 3, 6, 8, 5],
+    point_style: { fill: 'steelblue', radius: 4 }
+  }
+
+  const series_b = {
+    x: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    y: [2, 4, 6, 3, 7, 5, 8, 4, 6, 9],
+    point_style: { fill: 'orangered', radius: 4 }
+  }
+</script>
+
+<ScatterPlot
+  series={[series_a, series_b]}
+  x_label="X Axis"
+  y_label="Y Value"
+  markers="line+points"
+  style="height: 300px; width: 100%;"
+/>
+```
+
+## Display Modes
+
+ScatterPlot supports different marker modes: `points`, `line`, or `line+points`:
+
+```svelte example stackblitz
+<script>
+  import { ScatterPlot } from '$lib'
+
+  // Data for display modes
+  const data = {
+    x: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    y: [5, 7, 2, 8, 4, 9, 3, 6, 8, 5],
+    point_style: { fill: 'steelblue', radius: 5 }
+  }
+
+  const modes = ['points', 'line', 'line+points']
+</script>
+
+<div style="display: flex; flex-direction: column; gap: 1em;">
+  {#each modes as mode}
+    <div>
+      <h3>{mode}</h3>
+      <ScatterPlot
+        series={[data]}
+        markers={mode}
+        style="height: 200px; width: 100%;"
+      />
+    </div>
+  {/each}
+</div>
+```
+
+## Custom Tick Intervals
+
+You can specify custom tick intervals using negative values for `x_ticks` and `y_ticks`:
+
+```svelte example stackblitz
+<script>
+  import { ScatterPlot } from '$lib'
+
+  // Data with wider range for tick demonstration
+  const data = {
+    x: [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50],
+    y: [0, 25, 10, 35, 20, 45, 15, 30, 40, 5, 50],
+    point_style: { fill: 'steelblue', radius: 5 }
+  }
+
+  // Negative values represent intervals:
+  // x_ticks={-10} means "use intervals of 10 units"
+  // y_ticks={-5} means "use intervals of 5 units"
+</script>
+
+<ScatterPlot
+  series={[data]}
+  x_ticks={-10}
+  y_ticks={-5}
+  x_label="X Axis (interval=10)"
+  y_label="Y Axis (interval=5)"
+  style="height: 300px; width: 100%;"
+/>
+```
+
+## Negative Values and Custom Limits
+
+ScatterPlot handles negative values and allows setting custom axis limits:
+
+```svelte example stackblitz
+<script>
+  import { ScatterPlot } from '$lib'
+
+  // Data with negative values
+  const data = {
+    x: [-50, -40, -30, -20, -10, 0, 10, 20, 30, 40, 50],
+    y: [-25, -15, -5, 0, 10, 5, -10, 15, -20, 30, -30],
+    point_style: { fill: 'steelblue', radius: 5 }
+  }
+</script>
+
+<ScatterPlot
+  series={[data]}
+  x_lim={[-60, 60]}
+  y_lim={[-40, 40]}
+  x_ticks={-20}
+  y_ticks={-10}
+  x_label="X Axis"
+  y_label="Y Axis"
+  style="height: 300px; width: 100%;"
+/>
+```
+
+## Time-Based Scatter Plot
+
+Using time data on the x-axis with custom formatting:
+
+```svelte example stackblitz
+<script>
+  import { ScatterPlot } from '$lib'
+
+  // Generate dates for the past 30 days
+  const dates = Array.from({ length: 30 }, (_, idx) => {
+    const date = new Date()
+    date.setDate(date.getDate() - (30 - idx))
+    return date.getTime()
+  })
+
+  // Random data values
+  const values = Array.from({ length: 30 }, () => Math.random() * 100)
+
+  const time_data = {
+    x: dates,
+    y: values,
+    point_style: { fill: 'steelblue', radius: 4 }
+  }
+</script>
+
+<ScatterPlot
+  series={[time_data]}
+  markers="line+points"
+  x_format="%b %d"
+  x_ticks={-7}
+  y_ticks={-10}
+  x_label="Date"
+  y_label="Value"
+  style="height: 300px; width: 100%;"
+/>
+```
+
+## Multiple Series with Custom Tooltips
+
+Demonstrating custom tooltips with multiple series:
+
+```svelte example stackblitz
+<script>
+  import { ScatterPlot } from '$lib'
+
+  // Multiple series with metadata
+  const series_a = {
+    x: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    y: [5, 7, 2, 8, 4, 9, 3, 6, 8, 5],
+    point_style: { fill: 'steelblue', radius: 5 },
+    metadata: Array.from({ length: 10 }, (_, idx) => ({ name: `Point A${idx+1}`, series: 'Series A' }))
+  }
+
+  const series_b = {
+    x: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    y: [2, 4, 6, 3, 7, 5, 8, 4, 6, 9],
+    point_style: { fill: 'orangered', radius: 5 },
+    metadata: Array.from({ length: 10 }, (_, idx) => ({ name: `Point B${idx+1}`, series: 'Series B' }))
+  }
+
+  let selected_point = null
+</script>
+
+<ScatterPlot
+  series={[series_a, series_b]}
+  x_label="X Value"
+  y_label="Y Value"
+  markers="line+points"
+  change={(event) => (selected_point = event)}
+  style="height: 300px; width: 100%;"
+  tooltip={({ x, y, metadata }) => `
+    <div style="background: rgba(0,0,0,0.7); padding: 0.5em; border-radius: 4px;">
+      <strong>${metadata?.name || 'Point'}</strong><br />
+      Series: ${metadata?.series || 'Unknown'}<br />
+      X: ${x}, Y: ${y}
+    </div>
+  `}
+/>
+
+{#if selected_point}
+  <div style="margin-top: 1em; padding: 0.5em; border: 1px solid #ccc; border-radius: 4px;">
+    Selected point: (${selected_point.x}, ${selected_point.y})
+    {#if selected_point.metadata}
+      - ${selected_point.metadata.name} from ${selected_point.metadata.series}
+    {/if}
+  </div>
+{/if}
+```
+
+## Complete Feature Demo
+
+This example combines various features of the ScatterPlot component:
+
+```svelte example stackblitz
+<script>
+  import { ScatterPlot } from '$lib'
+
+  // Generate some complex data
+  function generate_data(count, x_min, x_max, y_callback, metadata_gen) {
+    const x_values = Array.from({ length: count }, (_, idx) =>
+      x_min + (x_max - x_min) * (idx / (count - 1))
+    )
+
+    const y_values = x_values.map(y_callback)
+
+    return {
+      x: x_values,
+      y: y_values,
+      metadata: metadata_gen ? x_values.map((x, idx) => metadata_gen(x, y_values[idx], idx)) : undefined
+    }
+  }
+
+  // Create three different series
+  const sine_data = {
+    ...generate_data(
+      50, -10, 10,
+      x => Math.sin(x) * 5,
+      (x, y, idx) => ({ type: 'sine', index: idx })
+    ),
+    point_style: { fill: 'rgb(65, 105, 225)', radius: 3 }
+  }
+
+  const cosine_data = {
+    ...generate_data(
+      50, -10, 10,
+      x => Math.cos(x) * 5,
+      (x, y, idx) => ({ type: 'cosine', index: idx })
+    ),
+    point_style: { fill: 'rgb(220, 20, 60)', radius: 3 }
+  }
+
+  const linear_data = {
+    ...generate_data(
+      20, -10, 10,
+      x => x * 0.5,
+      (x, y, idx) => ({ type: 'linear', index: idx })
+    ),
+    point_style: { fill: 'rgb(50, 205, 50)', radius: 4 }
+  }
+
+  let display_mode = 'line+points'
+  let x_tick_interval = -2
+  let y_tick_interval = -1
+</script>
+
+<div style="margin-bottom: 1em;">
+  <label>
+    Display Mode:
+    <select bind:value={display_mode}>
+      <option value="points">Points only</option>
+      <option value="line">Lines only</option>
+      <option value="line+points">Lines and Points</option>
+    </select>
+  </label>
+
+  <label style="margin-left: 1em;">
+    X-Tick Interval:
+    <select bind:value={x_tick_interval}>
+      <option value={-1}>1 unit</option>
+      <option value={-2}>2 units</option>
+      <option value={-5}>5 units</option>
+    </select>
+  </label>
+
+  <label style="margin-left: 1em;">
+    Y-Tick Interval:
+    <select bind:value={y_tick_interval}>
+      <option value={-1}>1 unit</option>
+      <option value={-2}>2 units</option>
+      <option value={-5}>5 units</option>
+    </select>
+  </label>
+</div>
+
+<ScatterPlot
+  series={[sine_data, cosine_data, linear_data]}
+  markers={display_mode}
+  x_ticks={x_tick_interval}
+  y_ticks={y_tick_interval}
+  x_lim={[-12, 12]}
+  y_lim={[-6, 6]}
+  x_label="X Axis"
+  y_label="Y Axis"
+  style="height: 400px; width: 100%;"
+  tooltip={({ x, y, metadata }) => `
+    <div style="background: rgba(0,0,0,0.8); color: white; padding: 0.5em; border-radius: 4px;">
+      <strong>${metadata?.type || 'Point'} #${metadata?.index ?? ''}</strong><br />
+      (${x.toFixed(2)}, ${y.toFixed(2)})
+    </div>
+  `}
+/>
+```

--- a/static/prism-vsc-dark-plus.css
+++ b/static/prism-vsc-dark-plus.css
@@ -5,9 +5,8 @@ code[class*='language-'] {
   color: #d4d4d4;
   font-size: 13px;
   text-shadow: none;
-  font-family:
-    Menlo, Monaco, Consolas, 'Andale Mono', 'Ubuntu Mono', 'Courier New',
-    monospace;
+  font-family: Menlo, Monaco, Consolas, 'Andale Mono', 'Ubuntu Mono',
+    'Courier New', monospace;
   direction: ltr;
   text-align: left;
   white-space: pre;

--- a/tests/unit/ElementTile.test.ts
+++ b/tests/unit/ElementTile.test.ts
@@ -59,7 +59,7 @@ describe(`ElementTile`, () => {
     expect(node.style.backgroundColor).toBe(`red`)
   })
 
-  // skipping for now as JSDOM doesn't actually apply the bg_color so ElementTile can't determine its text color from background
+  // skipping for now as happy-dom doesn't actually apply the bg_color so ElementTile can't determine its text color from background
   test.skip.each([
     [`red`, `white`],
     [`#eee`, `black`],

--- a/tests/unit/ScatterPlot.test.ts
+++ b/tests/unit/ScatterPlot.test.ts
@@ -1,14 +1,10 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
 import { ScatterPlot } from '$lib'
-import { mount, tick } from 'svelte'
-import {
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-  vi,
-} from 'vitest'
+import { mount } from 'svelte'
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
 
 describe(`ScatterPlot`, () => {
   // Add container with dimensions to body before each test
@@ -26,33 +22,31 @@ describe(`ScatterPlot`, () => {
 
       observe(target: Element) {
         // Simulate initial size reporting
-        setTimeout(() => {
-          this.callback(
-            [
-              {
-                target,
-                contentRect: {
-                  width: 800,
-                  height: 600,
-                  top: 0,
-                  left: 0,
-                  bottom: 600,
-                  right: 800,
-                  x: 0,
-                  y: 0,
-                } as DOMRectReadOnly,
-              } as ResizeObserverEntry,
-            ],
-            this as unknown as ResizeObserver,
-          )
-        }, 0)
+        this.callback(
+          [
+            {
+              target,
+              contentRect: {
+                width: 800,
+                height: 600,
+                top: 0,
+                left: 0,
+                bottom: 600,
+                right: 800,
+                x: 0,
+                y: 0,
+              } as DOMRectReadOnly,
+            } as ResizeObserverEntry,
+          ],
+          this as unknown as ResizeObserver,
+        )
       }
 
       unobserve() {}
       disconnect() {}
     }
 
-    // Mock getBoundingClientRect for SVG elements (needed for calculating mouse positions)
+    // Mock getBoundingClientRect for SVG elements
     Element.prototype.getBoundingClientRect = vi.fn(() => ({
       width: 800,
       height: 600,
@@ -66,11 +60,29 @@ describe(`ScatterPlot`, () => {
     }))
   })
 
-  // Ensure clean up after each test
-  afterEach(() => {
-    // Clean up DOM
-    document.body.innerHTML = ``
-  })
+  // Helper to simulate mouse events
+  function simulate_mouse_event(
+    element: Element | null,
+    event_type: string,
+    coords = { x: 400, y: 300 },
+  ) {
+    if (!element) return
+
+    const event = new MouseEvent(event_type, {
+      bubbles: true,
+      cancelable: true,
+      clientX: coords.x,
+      clientY: coords.y,
+    })
+
+    // Define offsetX and offsetY properties
+    Object.defineProperties(event, {
+      offsetX: { value: coords.x },
+      offsetY: { value: coords.y },
+    })
+
+    element.dispatchEvent(event)
+  }
 
   beforeEach(() => {
     // Reset document state
@@ -80,30 +92,21 @@ describe(`ScatterPlot`, () => {
     document.body.appendChild(container)
   })
 
-  test(`renders with default props`, async () => {
-    mount(ScatterPlot, {
-      target: document.querySelector(`div`)!,
-    })
-    await tick()
-    await tick() // Additional tick for SVG rendering
-    await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
+  test(`renders with default props and applies custom style`, () => {
+    // Default props
+    mount(ScatterPlot, { target: document.body })
 
-    const scatter = document.querySelector(`.scatter`)
+    let scatter = document.querySelector(`.scatter`)
     expect(scatter).toBeTruthy()
     expect(getComputedStyle(scatter!).width).toBe(`100%`)
-  })
 
-  test(`applies custom style`, async () => {
+    document.body.innerHTML = ``
+
+    // Custom style
     const style = `height: 300px; background: black;`
-    mount(ScatterPlot, {
-      target: document.querySelector(`div`)!,
-      props: { style },
-    })
-    await tick()
-    await tick() // Additional tick for SVG rendering
-    await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
+    mount(ScatterPlot, { target: document.body, props: { style } })
 
-    const scatter = document.querySelector(`.scatter`)
+    scatter = document.querySelector(`.scatter`)
     expect(scatter).toBeTruthy()
     expect(scatter!.getAttribute(`style`)).toContain(style)
   })
@@ -119,6 +122,7 @@ describe(`ScatterPlot`, () => {
       },
       x_lim: [null, null] as [number | null, number | null],
       y_lim: [null, null] as [number | null, number | null],
+      markers: `points` as const,
     },
     {
       name: `data with y limits`,
@@ -130,6 +134,7 @@ describe(`ScatterPlot`, () => {
       },
       x_lim: [null, null] as [number | null, number | null],
       y_lim: [0, 10] as [number | null, number | null],
+      markers: `line` as const,
     },
     {
       name: `data with x limits`,
@@ -141,38 +146,31 @@ describe(`ScatterPlot`, () => {
       },
       x_lim: [0, 5] as [number | null, number | null],
       y_lim: [null, null] as [number | null, number | null],
+      markers: `line+points` as const,
     },
   ])(
-    `renders with single data series: $name`,
-    async ({ data, x_lim, y_lim }) => {
+    `renders with different configurations: $name`,
+    ({ data, x_lim, y_lim, markers }) => {
       const component = mount(ScatterPlot, {
-        target: document.querySelector(`div`)!,
+        target: document.body,
         props: {
           series: [data],
           x_label: `X Axis`,
           y_label: `Y Axis`,
           x_lim,
           y_lim,
+          markers,
         },
       })
-      await tick()
-      await tick() // Additional tick for SVG rendering
-      await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
 
-      // Check if component mounted successfully
+      // Verify component mounted
       expect(component).toBeTruthy()
-
-      // Check if scatter component is rendered
       const scatter = document.querySelector(`.scatter`)
       expect(scatter).toBeTruthy()
     },
   )
 
-  test.each([
-    { name: `line+points`, markers: `line+points` as const },
-    { name: `points only`, markers: `points` as const },
-    { name: `line only`, markers: `line` as const },
-  ])(`renders with multiple data series: $name`, async ({ markers }) => {
+  test(`renders with multiple data series and handles empty data series`, () => {
     const series_a = {
       x: [1, 2, 3],
       y: [5, 3, 8],
@@ -187,138 +185,94 @@ describe(`ScatterPlot`, () => {
       metadata: { label: `Series B` } as Record<string, unknown>,
     }
 
+    // Test with multiple series
     const component = mount(ScatterPlot, {
-      target: document.querySelector(`div`)!,
-      props: {
-        series: [series_a, series_b],
-        markers,
-      },
+      target: document.body,
+      props: { series: [series_a, series_b], markers: `line+points` },
     })
-    await tick()
-    await tick() // Additional tick for SVG rendering
-    await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
 
-    // Just verify component mounted successfully
+    // Verify component mounted
     expect(component).toBeTruthy()
-
-    // Check if scatter component is rendered
     const scatter = document.querySelector(`.scatter`)
     expect(scatter).toBeTruthy()
+
+    document.body.innerHTML = ``
+
+    // Test empty data
+    const empty_component = mount(ScatterPlot, {
+      target: document.body,
+      props: { series: [] },
+    })
+
+    // Verify component mounted
+    expect(empty_component).toBeTruthy()
+    const empty_scatter = document.querySelector(`.scatter`)
+    expect(empty_scatter).toBeTruthy()
   })
 
-  test.each([
-    {
-      name: `numeric x and y ticks`,
-      x_ticks: -10,
-      y_ticks: -5,
-      x_format: `.0f`,
-      y_format: `.0f`,
-    },
-    {
-      name: `count-based ticks`,
-      x_ticks: 10,
-      y_ticks: 8,
-      x_format: `.1f`,
-      y_format: `.1f`,
-    },
-    {
-      name: `default ticks`,
-      x_ticks: undefined,
-      y_ticks: undefined,
-      x_format: `.0f`,
-      y_format: `.0f`,
-    },
-  ])(
-    `renders with custom tick formats: $name`,
-    async ({ x_ticks, y_ticks, x_format, y_format }) => {
-      const test_data = {
-        x: [0, 10, 20, 30, 40, 50],
-        y: [0, 30, 15, 45, 20, 50],
-        point_style: { fill: `steelblue`, radius: 5 },
-        metadata: { label: `Test Data` } as Record<string, unknown>,
-      }
-
-      const component = mount(ScatterPlot, {
-        target: document.querySelector(`div`)!,
-        props: {
-          series: [test_data],
-          x_ticks,
-          y_ticks,
-          x_format,
-          y_format,
-        },
-      })
-      await tick()
-      await tick() // Additional tick for SVG rendering
-      await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
-
-      // Just verify component mounted successfully
-      expect(component).toBeTruthy()
-
-      // Check if scatter component is rendered
-      const scatter = document.querySelector(`.scatter`)
-      expect(scatter).toBeTruthy()
-    },
-  )
-
-  test.each([
-    {
-      name: `basic negative values`,
-      data: {
-        x: [-50, -25, 0, 25, 50],
-        y: [-25, -10, 0, 10, 25],
-      },
-      x_lim: [-60, 60] as [number | null, number | null],
-      y_lim: [-30, 30] as [number | null, number | null],
-    },
-    {
-      name: `only positive values`,
-      data: {
-        x: [10, 20, 30, 40, 50],
-        y: [10, 20, 30, 40, 50],
-      },
-      x_lim: [0, 60] as [number | null, number | null],
-      y_lim: [0, 60] as [number | null, number | null],
-    },
-  ])(`handles custom ranges: $name`, async ({ data, x_lim, y_lim }) => {
-    const test_data = {
-      ...data,
+  test(`renders with different tick formats and data types`, () => {
+    // Test with numeric data
+    const numeric_data = {
+      x: [0, 10, 20, 30, 40, 50],
+      y: [0, 30, 15, 45, 20, 50],
       point_style: { fill: `steelblue`, radius: 5 },
-      metadata: { label: `Test Data` } as Record<string, unknown>,
     }
 
     const component = mount(ScatterPlot, {
-      target: document.querySelector(`div`)!,
+      target: document.body,
       props: {
-        series: [test_data],
-        x_lim,
-        y_lim,
-        x_ticks: -20,
-        y_ticks: -10,
+        series: [numeric_data],
+        x_ticks: -10,
+        y_ticks: -5,
+        x_format: `.0f`,
+        y_format: `.0f`,
       },
     })
-    await tick()
-    await tick() // Additional tick for SVG rendering
-    await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
 
-    // Just verify component mounted successfully
+    // Verify component mounted
     expect(component).toBeTruthy()
-
-    // Check if scatter component is rendered
     const scatter = document.querySelector(`.scatter`)
     expect(scatter).toBeTruthy()
+
+    document.body.innerHTML = ``
+
+    // Test with timestamp data
+    const timestamp_data = {
+      x: Array.from({ length: 12 }, (_, i) => {
+        const date = new Date()
+        date.setMonth(date.getMonth() - (12 - i))
+        return date.getTime()
+      }),
+      y: Array.from({ length: 12 }, () => Math.random() * 100),
+      point_style: { fill: `steelblue`, radius: 5 },
+    }
+
+    const time_component = mount(ScatterPlot, {
+      target: document.body,
+      props: {
+        series: [timestamp_data],
+        x_ticks: `month`,
+        y_ticks: 5,
+        x_format: `%b %Y`,
+        y_format: `.0f`,
+      },
+    })
+
+    // Verify component mounted
+    expect(time_component).toBeTruthy()
+    const time_scatter = document.querySelector(`.scatter`)
+    expect(time_scatter).toBeTruthy()
   })
 
-  test(`renders with units and formatted labels`, async () => {
+  test(`renders with various props (labels, padding, tooltips)`, () => {
     const test_data = {
       x: [1, 2, 3, 4, 5],
       y: [10, 20, 30, 40, 50],
       point_style: { fill: `steelblue`, radius: 5 },
-      metadata: { label: `Test Data` } as Record<string, unknown>,
     }
 
     const component = mount(ScatterPlot, {
-      target: document.querySelector(`div`)!,
+      target: document.body,
       props: {
         series: [test_data],
         x_label: `Time (s)`,
@@ -326,21 +280,23 @@ describe(`ScatterPlot`, () => {
         y_unit: `m/s`,
         x_format: `.1f`,
         y_format: `.0f`,
+        pad_top: 20,
+        pad_bottom: 50,
+        pad_left: 80,
+        pad_right: 30,
+        x_label_yshift: 10,
+        tooltip_point: { x: 3, y: 30 },
+        hovered: true,
       },
     })
-    await tick()
-    await tick() // Additional tick for SVG rendering
-    await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
 
-    // Just verify component mounted successfully
+    // Verify component mounted
     expect(component).toBeTruthy()
-
-    // Check if scatter component is rendered
     const scatter = document.querySelector(`.scatter`)
     expect(scatter).toBeTruthy()
   })
 
-  test(`handles mouse interactions correctly`, async () => {
+  test(`handles mouse events`, () => {
     const mock_change = vi.fn()
     const test_data = {
       x: [1, 2, 3, 4, 5],
@@ -350,70 +306,241 @@ describe(`ScatterPlot`, () => {
     }
 
     const component = mount(ScatterPlot, {
-      target: document.querySelector(`div`)!,
-      props: {
-        series: [test_data],
-        change: mock_change,
-      },
+      target: document.body,
+      props: { series: [test_data], change: mock_change },
     })
-    await tick()
-    await tick() // Additional tick for SVG rendering
-    await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
 
-    // Just verify component mounted successfully
+    // Verify component mounted
     expect(component).toBeTruthy()
-
-    // Check if scatter component is rendered
     const scatter = document.querySelector(`.scatter`)
     expect(scatter).toBeTruthy()
+
+    // Trigger mouse events on the container instead of the SVG
+    simulate_mouse_event(scatter, `mousemove`, { x: 400, y: 300 })
   })
 
-  test(`handles custom padding`, async () => {
+  test(`handles all edge cases and safeguards against invalid data`, () => {
+    // Create a series with all types of problematic data
+    const comprehensive_test_data = [
+      // Valid series with some missing/null data points
+      {
+        x: [1, 2, null, 4, 5] as (number | null | undefined)[],
+        y: [5, 4, undefined, 2, 1] as (number | null | undefined)[],
+        point_style: { fill: `steelblue`, radius: 5 },
+      },
+      // Completely null/undefined series item
+      null,
+      undefined,
+      // Valid item but with mismatched x/y lengths (5 vs 3)
+      { x: [10, 20, 30, 40, 50], y: [10, 20, 30] },
+      // Valid series with valid data
+      { x: [100, 200, 300], y: [10, 20, 30] },
+    ]
+
+    const component = mount(ScatterPlot, {
+      target: document.body,
+      props: {
+        series: comprehensive_test_data,
+        // Test various edge cases together
+        x_lim: [null, null] as [number | null, number | null],
+        y_lim: [null, null] as [number | null, number | null],
+        markers: `line+points`,
+      },
+    })
+
+    // Component should render without crashing
+    expect(component).toBeTruthy()
+    const scatter = document.querySelector(`.scatter`)
+    expect(scatter).toBeTruthy()
+
+    // Test with data that would be filtered out by range limits
+    const filtered_component = mount(ScatterPlot, {
+      target: document.body,
+      props: {
+        series: [{ x: [1, 2, 3], y: [4, 5, 6] }],
+        // Set limits that will filter out all data points
+        x_lim: [100, 200] as [number, number],
+        y_lim: [100, 200] as [number, number],
+      },
+    })
+
+    // Should still render without valid data points
+    expect(filtered_component).toBeTruthy()
+    const filtered_scatter = document.querySelector(`.scatter`)
+    expect(filtered_scatter).toBeTruthy()
+  })
+
+  test(`handles negative values and zero line rendering`, () => {
+    // Create data with positive and negative values
+    const test_data = { x: [1, 2, 3, 4, 5], y: [-10, -5, 0, 5, 10] }
+
+    const component = mount(ScatterPlot, {
+      target: document.body,
+      props: { series: [test_data], y_lim: [-15, 15] },
+    })
+
+    // Verify component mounted
+    expect(component).toBeTruthy()
+    const scatter = document.querySelector(`.scatter`)
+    expect(scatter).toBeTruthy()
+
+    // Test with only positive values
+    const pos_component = mount(ScatterPlot, {
+      target: document.body,
+      props: {
+        series: [{ x: [1, 2, 3, 4, 5], y: [5, 10, 15, 20, 25] }],
+        y_lim: [0, 30],
+      },
+    })
+
+    // Verify component mounted
+    expect(pos_component).toBeTruthy()
+    const pos_scatter = document.querySelector(`.scatter`)
+    expect(pos_scatter).toBeTruthy()
+  })
+
+  // Test the tooltip rendering directly - this exercises the format_value function
+  test(`directly tests format_value function through tooltip rendering`, () => {
+    // Test both time formatting and numeric formatting
+    const timestamp = new Date(2023, 5, 15).getTime() // June 15, 2023
+    const decimal_value = 123.45
+
+    // Mount with tooltip_point and explicitly set formats
+    const component = mount(ScatterPlot, {
+      target: document.body,
+      props: {
+        series: [{ x: [timestamp], y: [decimal_value] }],
+        tooltip_point: { x: timestamp, y: decimal_value },
+        hovered: true,
+        x_format: `%b %d, %Y`,
+        y_format: `.2f`,
+      },
+    })
+
+    // Component should render
+    expect(component).toBeTruthy()
+  })
+
+  // Test using default tooltip
+  test(`renders with default tooltip`, () => {
+    const component = mount(ScatterPlot, {
+      target: document.body,
+      props: {
+        series: [{ x: [1, 2, 3], y: [10, 20, 30] }],
+        tooltip_point: { x: 2, y: 20 },
+        hovered: true,
+      },
+    })
+
+    // Component should render
+    expect(component).toBeTruthy()
+  })
+
+  // Test on_mouse_move with complex scenarios
+  test(`exercises on_mouse_move function with different data configurations`, () => {
+    // Use a series with multiple points to test finding closest point
     const test_data = {
-      x: [1, 2, 3, 4, 5],
-      y: [10, 20, 30, 40, 50],
-      point_style: { fill: `steelblue`, radius: 5 },
-      metadata: { label: `Test Data` } as Record<string, unknown>,
+      x: [10, 20, 30, 40, 50],
+      y: [5, 15, 25, 35, 45],
+      metadata: { series: `Series A` },
     }
 
+    const mock_change = vi.fn()
+
     const component = mount(ScatterPlot, {
-      target: document.querySelector(`div`)!,
-      props: {
-        series: [test_data],
-        pad_top: 20,
-        pad_bottom: 50,
-        pad_left: 80,
-        pad_right: 30,
-      },
+      target: document.body,
+      props: { series: [test_data], change: mock_change },
     })
-    await tick()
-    await tick() // Additional tick for SVG rendering
-    await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
 
-    // Just verify component mounted successfully
+    // Verify component mounted
     expect(component).toBeTruthy()
-
-    // Check if scatter component is rendered
     const scatter = document.querySelector(`.scatter`)
     expect(scatter).toBeTruthy()
+
+    // Simulate mouse moving over different areas
+    simulate_mouse_event(scatter, `mousemove`, { x: 200, y: 200 }) // Middle of plot
+    simulate_mouse_event(scatter, `mousemove`, { x: 100, y: 100 }) // Top-left
+    simulate_mouse_event(scatter, `mousemove`, { x: 700, y: 500 }) // Bottom-right
+
+    // Test with multiple series
+    document.body.innerHTML = ``
+    document.body.appendChild(document.createElement(`div`))
+    document.querySelector(`div`)!.setAttribute(`style`, container_style)
+
+    const series_a = {
+      x: [10, 20, 30],
+      y: [10, 20, 30],
+      metadata: { series: `A` },
+    }
+
+    const series_b = {
+      x: [15, 25, 35],
+      y: [15, 25, 35],
+      metadata: { series: `B` },
+    }
+
+    const multi_component = mount(ScatterPlot, {
+      target: document.body,
+      props: { series: [series_a, series_b], change: mock_change },
+    })
+
+    // Verify component mounted
+    expect(multi_component).toBeTruthy()
+    const multi_scatter = document.querySelector(`.scatter`)
+    expect(multi_scatter).toBeTruthy()
+
+    // Simulate mouse moving over area where points from both series exist
+    simulate_mouse_event(multi_scatter, `mousemove`, { x: 400, y: 300 })
   })
 
-  test(`handles empty data series`, async () => {
-    const component = mount(ScatterPlot, {
-      target: document.querySelector(`div`)!,
-      props: {
-        series: [],
-      },
+  // Test with various format specifiers to exercise the format_value function
+  test(`handles various format specifiers in format_value function`, () => {
+    // Test various numeric format specifiers
+    const formats = [
+      { value: 12.345, format: `.1f`, expected: `12.3` },
+      { value: 12.345, format: `.3f`, expected: `12.345` },
+      { value: 12.345, format: `.5f`, expected: `12.34500` }, // Will strip trailing zeros
+      { value: 12, format: `.2f`, expected: `12` }, // Integer should not show decimal
+      { value: 1234.5, format: `,.0f`, expected: `1,235` }, // With thousands separator
+    ]
+
+    formats.forEach(({ value, format }) => {
+      const component = mount(ScatterPlot, {
+        target: document.body,
+        props: {
+          series: [{ x: [1], y: [value] }],
+          y_format: format,
+          tooltip_point: { x: 1, y: value },
+          hovered: true,
+        },
+      })
+
+      expect(component).toBeTruthy()
     })
-    await tick()
-    await tick() // Additional tick for SVG rendering
-    await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
 
-    // Just verify component mounted successfully
-    expect(component).toBeTruthy()
+    // Test time format specifiers
+    const now = new Date()
+    const timestamp = now.getTime()
 
-    // Check if scatter component is rendered
-    const scatter = document.querySelector(`.scatter`)
-    expect(scatter).toBeTruthy()
+    const time_formats = [
+      { format: `%Y`, description: `year only` },
+      { format: `%b %Y`, description: `month and year` },
+      { format: `%B %d, %Y`, description: `full date` },
+      { format: `%H:%M`, description: `time only` },
+    ]
+
+    time_formats.forEach(({ format }) => {
+      const component = mount(ScatterPlot, {
+        target: document.body,
+        props: {
+          series: [{ x: [timestamp], y: [1] }],
+          x_format: format,
+          tooltip_point: { x: timestamp, y: 1 },
+          hovered: true,
+        },
+      })
+
+      expect(component).toBeTruthy()
+    })
   })
 })

--- a/tests/unit/ScatterPlot.test.ts
+++ b/tests/unit/ScatterPlot.test.ts
@@ -21,23 +21,19 @@ describe(`ScatterPlot`, () => {
       }
 
       observe(target: Element) {
+        const dom_rect = {
+          width: 800,
+          height: 600,
+          top: 0,
+          left: 0,
+          bottom: 600,
+          right: 800,
+          x: 0,
+          y: 0,
+        }
         // Simulate initial size reporting
         this.callback(
-          [
-            {
-              target,
-              contentRect: {
-                width: 800,
-                height: 600,
-                top: 0,
-                left: 0,
-                bottom: 600,
-                right: 800,
-                x: 0,
-                y: 0,
-              } as DOMRectReadOnly,
-            } as ResizeObserverEntry,
-          ],
+          [{ target, contentRect: dom_rect } as ResizeObserverEntry],
           this as unknown as ResizeObserver,
         )
       }

--- a/tests/unit/ScatterPlot.test.ts
+++ b/tests/unit/ScatterPlot.test.ts
@@ -1,12 +1,80 @@
 import { ScatterPlot } from '$lib'
 import { mount, tick } from 'svelte'
-import { beforeEach, describe, expect, test } from 'vitest'
-import { doc_query } from '.'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest'
 
 describe(`ScatterPlot`, () => {
   // Add container with dimensions to body before each test
   const container_style = `width: 800px; height: 600px; position: relative;`
+
+  // Mock ResizeObserver for Svelte 5
+  beforeAll(() => {
+    // Mock ResizeObserver
+    globalThis.ResizeObserver = class ResizeObserver {
+      callback: ResizeObserverCallback
+
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback
+      }
+
+      observe(target: Element) {
+        // Simulate initial size reporting
+        setTimeout(() => {
+          this.callback(
+            [
+              {
+                target,
+                contentRect: {
+                  width: 800,
+                  height: 600,
+                  top: 0,
+                  left: 0,
+                  bottom: 600,
+                  right: 800,
+                  x: 0,
+                  y: 0,
+                } as DOMRectReadOnly,
+              } as ResizeObserverEntry,
+            ],
+            this as unknown as ResizeObserver,
+          )
+        }, 0)
+      }
+
+      unobserve() {}
+      disconnect() {}
+    }
+
+    // Mock getBoundingClientRect for SVG elements (needed for calculating mouse positions)
+    Element.prototype.getBoundingClientRect = vi.fn(() => ({
+      width: 800,
+      height: 600,
+      top: 0,
+      left: 0,
+      bottom: 600,
+      right: 800,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    }))
+  })
+
+  // Ensure clean up after each test
+  afterEach(() => {
+    // Clean up DOM
+    document.body.innerHTML = ``
+  })
+
   beforeEach(() => {
+    // Reset document state
+    document.body.innerHTML = ``
     const container = document.createElement(`div`)
     container.setAttribute(`style`, container_style)
     document.body.appendChild(container)
@@ -17,10 +85,12 @@ describe(`ScatterPlot`, () => {
       target: document.querySelector(`div`)!,
     })
     await tick()
+    await tick() // Additional tick for SVG rendering
+    await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
 
-    const scatter = doc_query(`.scatter`)
+    const scatter = document.querySelector(`.scatter`)
     expect(scatter).toBeTruthy()
-    expect(getComputedStyle(scatter).width).toBe(`100%`)
+    expect(getComputedStyle(scatter!).width).toBe(`100%`)
   })
 
   test(`applies custom style`, async () => {
@@ -30,8 +100,320 @@ describe(`ScatterPlot`, () => {
       props: { style },
     })
     await tick()
+    await tick() // Additional tick for SVG rendering
+    await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
 
-    const scatter = doc_query(`.scatter`)
-    expect(scatter.getAttribute(`style`)).toBe(style)
+    const scatter = document.querySelector(`.scatter`)
+    expect(scatter).toBeTruthy()
+    expect(scatter!.getAttribute(`style`)).toContain(style)
+  })
+
+  test.each([
+    {
+      name: `basic data`,
+      data: {
+        x: [1, 2, 3, 4, 5],
+        y: [5, 3, 8, 2, 7],
+        point_style: { fill: `steelblue`, radius: 5 },
+        metadata: { label: `Series 1` } as Record<string, unknown>,
+      },
+      x_lim: [null, null] as [number | null, number | null],
+      y_lim: [null, null] as [number | null, number | null],
+    },
+    {
+      name: `data with y limits`,
+      data: {
+        x: [1, 2, 3, 4, 5],
+        y: [5, 3, 20, 2, 7],
+        point_style: { fill: `steelblue`, radius: 5 },
+        metadata: { label: `Series 2` } as Record<string, unknown>,
+      },
+      x_lim: [null, null] as [number | null, number | null],
+      y_lim: [0, 10] as [number | null, number | null],
+    },
+    {
+      name: `data with x limits`,
+      data: {
+        x: [0, 1, 2, 3, 10],
+        y: [5, 3, 8, 2, 7],
+        point_style: { fill: `steelblue`, radius: 5 },
+        metadata: { label: `Series 3` } as Record<string, unknown>,
+      },
+      x_lim: [0, 5] as [number | null, number | null],
+      y_lim: [null, null] as [number | null, number | null],
+    },
+  ])(
+    `renders with single data series: $name`,
+    async ({ data, x_lim, y_lim }) => {
+      const component = mount(ScatterPlot, {
+        target: document.querySelector(`div`)!,
+        props: {
+          series: [data],
+          x_label: `X Axis`,
+          y_label: `Y Axis`,
+          x_lim,
+          y_lim,
+        },
+      })
+      await tick()
+      await tick() // Additional tick for SVG rendering
+      await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
+
+      // Check if component mounted successfully
+      expect(component).toBeTruthy()
+
+      // Check if scatter component is rendered
+      const scatter = document.querySelector(`.scatter`)
+      expect(scatter).toBeTruthy()
+    },
+  )
+
+  test.each([
+    { name: `line+points`, markers: `line+points` as const },
+    { name: `points only`, markers: `points` as const },
+    { name: `line only`, markers: `line` as const },
+  ])(`renders with multiple data series: $name`, async ({ markers }) => {
+    const series_a = {
+      x: [1, 2, 3],
+      y: [5, 3, 8],
+      point_style: { fill: `steelblue`, radius: 4 },
+      metadata: { label: `Series A` } as Record<string, unknown>,
+    }
+
+    const series_b = {
+      x: [1, 2, 3],
+      y: [2, 5, 3],
+      point_style: { fill: `orangered`, radius: 4 },
+      metadata: { label: `Series B` } as Record<string, unknown>,
+    }
+
+    const component = mount(ScatterPlot, {
+      target: document.querySelector(`div`)!,
+      props: {
+        series: [series_a, series_b],
+        markers,
+      },
+    })
+    await tick()
+    await tick() // Additional tick for SVG rendering
+    await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
+
+    // Just verify component mounted successfully
+    expect(component).toBeTruthy()
+
+    // Check if scatter component is rendered
+    const scatter = document.querySelector(`.scatter`)
+    expect(scatter).toBeTruthy()
+  })
+
+  test.each([
+    {
+      name: `numeric x and y ticks`,
+      x_ticks: -10,
+      y_ticks: -5,
+      x_format: `.0f`,
+      y_format: `.0f`,
+    },
+    {
+      name: `count-based ticks`,
+      x_ticks: 10,
+      y_ticks: 8,
+      x_format: `.1f`,
+      y_format: `.1f`,
+    },
+    {
+      name: `default ticks`,
+      x_ticks: undefined,
+      y_ticks: undefined,
+      x_format: `.0f`,
+      y_format: `.0f`,
+    },
+  ])(
+    `renders with custom tick formats: $name`,
+    async ({ x_ticks, y_ticks, x_format, y_format }) => {
+      const test_data = {
+        x: [0, 10, 20, 30, 40, 50],
+        y: [0, 30, 15, 45, 20, 50],
+        point_style: { fill: `steelblue`, radius: 5 },
+        metadata: { label: `Test Data` } as Record<string, unknown>,
+      }
+
+      const component = mount(ScatterPlot, {
+        target: document.querySelector(`div`)!,
+        props: {
+          series: [test_data],
+          x_ticks,
+          y_ticks,
+          x_format,
+          y_format,
+        },
+      })
+      await tick()
+      await tick() // Additional tick for SVG rendering
+      await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
+
+      // Just verify component mounted successfully
+      expect(component).toBeTruthy()
+
+      // Check if scatter component is rendered
+      const scatter = document.querySelector(`.scatter`)
+      expect(scatter).toBeTruthy()
+    },
+  )
+
+  test.each([
+    {
+      name: `basic negative values`,
+      data: {
+        x: [-50, -25, 0, 25, 50],
+        y: [-25, -10, 0, 10, 25],
+      },
+      x_lim: [-60, 60] as [number | null, number | null],
+      y_lim: [-30, 30] as [number | null, number | null],
+    },
+    {
+      name: `only positive values`,
+      data: {
+        x: [10, 20, 30, 40, 50],
+        y: [10, 20, 30, 40, 50],
+      },
+      x_lim: [0, 60] as [number | null, number | null],
+      y_lim: [0, 60] as [number | null, number | null],
+    },
+  ])(`handles custom ranges: $name`, async ({ data, x_lim, y_lim }) => {
+    const test_data = {
+      ...data,
+      point_style: { fill: `steelblue`, radius: 5 },
+      metadata: { label: `Test Data` } as Record<string, unknown>,
+    }
+
+    const component = mount(ScatterPlot, {
+      target: document.querySelector(`div`)!,
+      props: {
+        series: [test_data],
+        x_lim,
+        y_lim,
+        x_ticks: -20,
+        y_ticks: -10,
+      },
+    })
+    await tick()
+    await tick() // Additional tick for SVG rendering
+    await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
+
+    // Just verify component mounted successfully
+    expect(component).toBeTruthy()
+
+    // Check if scatter component is rendered
+    const scatter = document.querySelector(`.scatter`)
+    expect(scatter).toBeTruthy()
+  })
+
+  test(`renders with units and formatted labels`, async () => {
+    const test_data = {
+      x: [1, 2, 3, 4, 5],
+      y: [10, 20, 30, 40, 50],
+      point_style: { fill: `steelblue`, radius: 5 },
+      metadata: { label: `Test Data` } as Record<string, unknown>,
+    }
+
+    const component = mount(ScatterPlot, {
+      target: document.querySelector(`div`)!,
+      props: {
+        series: [test_data],
+        x_label: `Time (s)`,
+        y_label: `Speed`,
+        y_unit: `m/s`,
+        x_format: `.1f`,
+        y_format: `.0f`,
+      },
+    })
+    await tick()
+    await tick() // Additional tick for SVG rendering
+    await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
+
+    // Just verify component mounted successfully
+    expect(component).toBeTruthy()
+
+    // Check if scatter component is rendered
+    const scatter = document.querySelector(`.scatter`)
+    expect(scatter).toBeTruthy()
+  })
+
+  test(`handles mouse interactions correctly`, async () => {
+    const mock_change = vi.fn()
+    const test_data = {
+      x: [1, 2, 3, 4, 5],
+      y: [10, 20, 30, 40, 50],
+      point_style: { fill: `steelblue`, radius: 5 },
+      metadata: { label: `Test Data` } as Record<string, unknown>,
+    }
+
+    const component = mount(ScatterPlot, {
+      target: document.querySelector(`div`)!,
+      props: {
+        series: [test_data],
+        change: mock_change,
+      },
+    })
+    await tick()
+    await tick() // Additional tick for SVG rendering
+    await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
+
+    // Just verify component mounted successfully
+    expect(component).toBeTruthy()
+
+    // Check if scatter component is rendered
+    const scatter = document.querySelector(`.scatter`)
+    expect(scatter).toBeTruthy()
+  })
+
+  test(`handles custom padding`, async () => {
+    const test_data = {
+      x: [1, 2, 3, 4, 5],
+      y: [10, 20, 30, 40, 50],
+      point_style: { fill: `steelblue`, radius: 5 },
+      metadata: { label: `Test Data` } as Record<string, unknown>,
+    }
+
+    const component = mount(ScatterPlot, {
+      target: document.querySelector(`div`)!,
+      props: {
+        series: [test_data],
+        pad_top: 20,
+        pad_bottom: 50,
+        pad_left: 80,
+        pad_right: 30,
+      },
+    })
+    await tick()
+    await tick() // Additional tick for SVG rendering
+    await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
+
+    // Just verify component mounted successfully
+    expect(component).toBeTruthy()
+
+    // Check if scatter component is rendered
+    const scatter = document.querySelector(`.scatter`)
+    expect(scatter).toBeTruthy()
+  })
+
+  test(`handles empty data series`, async () => {
+    const component = mount(ScatterPlot, {
+      target: document.querySelector(`div`)!,
+      props: {
+        series: [],
+      },
+    })
+    await tick()
+    await tick() // Additional tick for SVG rendering
+    await new Promise((resolve) => setTimeout(resolve, 0)) // Allow ResizeObserver to fire
+
+    // Just verify component mounted successfully
+    expect(component).toBeTruthy()
+
+    // Check if scatter component is rendered
+    const scatter = document.querySelector(`.scatter`)
+    expect(scatter).toBeTruthy()
   })
 })

--- a/tests/unit/ScatterPoint.test.ts
+++ b/tests/unit/ScatterPoint.test.ts
@@ -110,7 +110,7 @@ describe(`ScatterPoint`, () => {
     const g = doc_query(`g`)
     const transform = g.getAttribute(`transform`)
     expect(transform).toBe(
-      // TODO should expect next line but translate doesn't seem to happen in JSDOM
+      // TODO should expect next line but translate doesn't seem to happen in happy-dom
       // `translate(${props.x + offset.x} ${props.y + offset.y})`,
       `translate(0 0)`,
     )

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig(({ mode }) => ({
   plugins: [sveltekit(), mdsvexamples],
 
   test: {
-    environment: `jsdom`,
+    environment: `happy-dom`,
     css: true,
     coverage: {
       reporter: [`text`, `json-summary`],


### PR DESCRIPTION
- bump versions of dependencies including @sveltejs/kit, svelte, three, and eslint-plugin-svelte.
- add various ScatterPlot usage examples and src/routes/(demos)/scatter-plot/+page.md
- many new unit tests for ScatterPlot covering various data and custom tick formats