### PR TITLE
Make `ScatterPlot.svelte` drag-zoomable and add auto-placed `ColorBar`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,5 +13,6 @@ jobs:
   tests:
     uses: janosh/workflows/.github/workflows/npm-test.yml@main
     with:
-      install-cmd: npm install --force
       test-cmd: npm run test:unit
+      install-e2e: npx playwright install chromium
+      e2e-test-cmd: npx playwright test tests/*.ts

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "d3-scale-chromatic": "^3.1.0",
     "d3-shape": "^3.2.0",
     "highlight.js": "^11.11.1",
-    "svelte": "5.27.0",
+    "svelte": "5.27.1",
     "svelte-multiselect": "11.0.0-rc.1",
     "svelte-zoo": "^0.4.17",
     "three": "^0.175.0"
@@ -77,7 +77,7 @@
     "svelte2tsx": "^0.7.36",
     "typescript": "5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.0",
+    "vite": "^6.3.1",
     "vitest": "^3.1.1"
   },
   "keywords": [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,5 +5,5 @@ export default {
     command: `vite dev --port 3005`,
     port: 3005,
   },
-  timeout: 15_000, // Global timeout per test
+  timeout: 20_000, // Global timeout per test
 } satisfies PlaywrightTestConfig

--- a/routes/scatter-plot-e2e/+page.svelte
+++ b/routes/scatter-plot-e2e/+page.svelte
@@ -1,0 +1,54 @@
+<section id="colorbar-auto-placement">
+  <h2>ColorBar Auto Placement</h2>
+  <p>ColorBar automatically positions itself in the least dense quadrant.</p>
+  <div class="plot-grid">
+    <div id="colorbar-top-left" class="plot-container">
+      <h3>Top Left Placement</h3>
+      <ScatterPlot
+        series={top_left_series}
+        x_lim={[0, 100]}
+        y_lim={[0, 100]}
+        padding={{ t: 10, b: 40, l: 40, r: 10 }}
+        color_bar={{ label: `TL Bar`, tick_labels: 3 }}
+        show_color_bar
+      />
+    </div>
+    <div id="colorbar-top-right" class="plot-container">
+      <h3>Top Right Placement</h3>
+      <ScatterPlot
+        series={top_right_series}
+        x_lim={[0, 100]}
+        y_lim={[0, 100]}
+        padding={{ t: 10, b: 40, l: 40, r: 10 }}
+        color_bar={{ label: `TR Bar`, tick_labels: 3 }}
+        show_color_bar
+      />
+    </div>
+    <div id="colorbar-bottom-left" class="plot-container">
+      <h3>Bottom Left Placement</h3>
+      <ScatterPlot
+        series={bottom_left_series}
+        x_lim={[0, 100]}
+        y_lim={[0, 100]}
+        padding={{ t: 10, b: 40, l: 40, r: 10 }}
+        color_bar={{ label: `BL Bar`, tick_labels: 3 }}
+        show_color_bar
+      />
+    </div>
+    <div id="colorbar-bottom-right" class="plot-container">
+      <h3>Bottom Right Placement</h3>
+      <ScatterPlot
+        series={bottom_right_series}
+        x_lim={[0, 100]}
+        y_lim={[0, 100]}
+        padding={{ t: 10, b: 40, l: 40, r: 10 }}
+        color_bar={{ label: `BR Bar`, tick_labels: 3 }}
+        show_color_bar
+      />
+    </div>
+  </div>
+</section>
+
+<style>
+  /* ... existing style ... */
+</style>

--- a/src/lib/plot/Line.svelte
+++ b/src/lib/plot/Line.svelte
@@ -14,7 +14,6 @@
     origin: [number, number]
     points: [number, number][]
   }
-
   let {
     line_color = `rgba(255, 255, 255, 0.5)`,
     line_width = 2,
@@ -39,7 +38,9 @@
   let [x_min, x_max] = $derived(extent(points.map((p) => p[0])))
   let line_path = $derived(lineGenerator(points) ?? ``)
   let ymin = $derived(origin[1] ?? min(points.map((p) => p[1])))
-  let area_path = $derived(`${line_path}L${x_max},${ymin}L${x_min},${ymin}Z`)
+  let area_path = $derived(
+    line_path ? `${line_path}L${x_max},${ymin}L${x_min},${ymin}Z` : ``,
+  )
 
   const tweened_line = new Tween(``, tween_params)
   const tweened_area = new Tween(``, tween_params)

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -34,6 +34,20 @@
 
   type TimeInterval = `day` | `month` | `year`
   type ScaleType = `linear` | `log`
+  // internal point representation that includes extra properties
+  interface InternalPoint extends Point {
+    color_value?: number | null
+    metadata?: Record<string, unknown>
+    point_style?: Record<string, string | number>
+    point_hover?: Record<string, string | number>
+    point_label?: {
+      text?: string
+      style?: Record<string, string | number>
+      position?: `top` | `bottom` | `left` | `right`
+    }
+    point_offset?: { x: number; y: number }
+    point_tween_duration?: number
+  }
 
   interface Props {
     series?: DataSeries[]
@@ -106,6 +120,15 @@
   let width = $state(0)
   let height = $state(0)
 
+  // State for zooming
+  let drag_start_coords = $state<{ x: number; y: number } | null>(null)
+  let drag_current_coords = $state<{ x: number; y: number } | null>(null)
+
+  let initial_x_range = $state<[number, number]>([0, 1])
+  let initial_y_range = $state<[number, number]>([0, 1])
+  let current_x_range = $state<[number, number]>([0, 1])
+  let current_y_range = $state<[number, number]>([0, 1])
+
   // Create raw data points from all series
   let all_points = $derived(
     series
@@ -164,11 +187,30 @@
     get_nice_data_range(all_points, (point) => point.y, y_lim, y_scale_type, false),
   )
 
-  // Use provided explicit ranges if available, otherwise use auto-computed ranges
-  let effective_x_range = $derived(x_range ?? auto_x_range)
-  let effective_y_range = $derived(y_range ?? auto_y_range)
-  let [x_min, x_max] = $derived(effective_x_range)
-  let [y_min, y_max] = $derived(effective_y_range)
+  // Store initial ranges and initialize current ranges
+  $effect(() => {
+    const new_initial_x = x_range ?? auto_x_range
+    const new_initial_y = y_range ?? auto_y_range
+
+    // Only update if the initial range fundamentally changes, force type
+    if (
+      new_initial_x[0] !== initial_x_range[0] ||
+      new_initial_x[1] !== initial_x_range[1]
+    ) {
+      initial_x_range = new_initial_x as [number, number]
+      current_x_range = new_initial_x as [number, number]
+    }
+    if (
+      new_initial_y[0] !== initial_y_range[0] ||
+      new_initial_y[1] !== initial_y_range[1]
+    ) {
+      initial_y_range = new_initial_y as [number, number]
+      current_y_range = new_initial_y as [number, number]
+    }
+  })
+
+  let [x_min, x_max] = $derived(current_x_range) // Use current range for scales/axes
+  let [y_min, y_max] = $derived(current_y_range) // Use current range for scales/axes
 
   // Create auto color range
   let auto_color_range = $derived(
@@ -181,8 +223,8 @@
   // Validate log scale ranges
   $effect(() => {
     for (const { scale_type, range, axis } of [
-      { scale_type: x_scale_type, range: effective_x_range, axis: `x` },
-      { scale_type: y_scale_type, range: effective_y_range, axis: `y` },
+      { scale_type: x_scale_type, range: current_x_range, axis: `x` },
+      { scale_type: y_scale_type, range: current_y_range, axis: `y` },
     ]) {
       if (scale_type === `log` && (range[0] <= 0 || range[1] <= 0)) {
         const point = range[0] <= 0 ? `minimum: ${range[0]}` : `maximum: ${range[1]}`
@@ -238,12 +280,18 @@
   // Filter series data to only include points within bounds
   let filtered_series = $derived(
     series.map((data_series) => {
-      if (!data_series)
-        return { filtered_data: [] } as unknown as DataSeries & { filtered_data: Point[] }
+      if (!data_series) {
+        // Return empty data consistent with DataSeries structure
+        return {
+          x: [],
+          y: [],
+          filtered_data: [],
+        } as unknown as DataSeries & { filtered_data: Point[] }
+      }
 
       const { x: xs, y: ys, color_values, ...rest } = data_series
 
-      // Process each point with its properties
+      // Process points internally, adding properties beyond the base Point type
       const processed_points = xs.map((x, idx) => {
         const y = ys[idx]
         const color_value = color_values?.[idx]
@@ -265,7 +313,7 @@
           x,
           y,
           color_value,
-          metadata: process_prop(rest.metadata, idx),
+          metadata: process_prop(rest.metadata, idx), // Matches InternalPoint.metadata
           point_style: process_prop(rest.point_style, idx),
           point_hover: process_prop(rest.point_hover, idx),
           point_label: process_prop(rest.point_label, idx),
@@ -275,7 +323,8 @@
       })
 
       // Filter to points within the plot bounds
-      const filtered_data = processed_points.filter(
+      // This data contains the extra properties
+      const filtered_data_with_extras = processed_points.filter(
         (pt) =>
           !isNaN(pt.x) &&
           pt.x !== null &&
@@ -287,7 +336,11 @@
           pt.y <= y_max,
       )
 
-      return { ...data_series, filtered_data }
+      // Return structure consistent with DataSeries but acknowledge internal data structure
+      return {
+        ...data_series,
+        filtered_data: filtered_data_with_extras as Point[], // Cast here
+      } as DataSeries & { filtered_data: Point[] }
     }),
   )
 
@@ -404,6 +457,92 @@
       : formatted
   }
 
+  function get_relative_coords(evt: MouseEvent): { x: number; y: number } | null {
+    const svg_box = (evt.currentTarget as SVGElement)?.getBoundingClientRect()
+    if (!svg_box) return null
+    return {
+      x: evt.clientX - svg_box.left,
+      y: evt.clientY - svg_box.top,
+    }
+  }
+
+  function handle_mouse_down(evt: MouseEvent) {
+    const coords = get_relative_coords(evt)
+    if (!coords) return
+    drag_start_coords = coords
+    drag_current_coords = coords // Initialize current coords
+
+    // Prevent text selection during drag
+    evt.preventDefault()
+  }
+
+  function handle_mouse_move(evt: MouseEvent) {
+    find_closest_point(evt)
+    if (!drag_start_coords) return // Exit if not dragging
+
+    const coords = get_relative_coords(evt)
+    if (!coords) return
+    drag_current_coords = coords
+  }
+
+  function handle_mouse_up(_evt: MouseEvent) {
+    if (drag_start_coords && drag_current_coords) {
+      // Use current scales to invert screen coords to data coords
+      const start_data_x_val = x_scale_fn.invert(drag_start_coords.x)
+      const end_data_x_val = x_scale_fn.invert(drag_current_coords.x)
+      const start_data_y_val = y_scale_fn.invert(drag_start_coords.y)
+      const end_data_y_val = y_scale_fn.invert(drag_current_coords.y)
+
+      // Ensure range is not zero and order is correct
+      let x1: number, x2: number
+      if (start_data_x_val instanceof Date && end_data_x_val instanceof Date) {
+        x1 = start_data_x_val.getTime()
+        x2 = end_data_x_val.getTime()
+      } else if (
+        typeof start_data_x_val === `number` &&
+        typeof end_data_x_val === `number`
+      ) {
+        x1 = start_data_x_val
+        x2 = end_data_x_val
+      } else {
+        console.error(`Mismatched types for x-axis zoom calculation`)
+        return // Abort zoom if types are wrong
+      }
+
+      const next_x_range: [number, number] = [Math.min(x1, x2), Math.max(x1, x2)]
+      // Y axis is always number
+      const next_y_range: [number, number] = [
+        Math.min(start_data_y_val, end_data_y_val),
+        Math.max(start_data_y_val, end_data_y_val),
+      ]
+
+      if (next_x_range[0] !== next_x_range[1] && next_y_range[0] !== next_y_range[1]) {
+        current_x_range = next_x_range
+        current_y_range = next_y_range
+      }
+    }
+
+    // Reset states
+    drag_start_coords = null
+    drag_current_coords = null
+    document.body.style.cursor = `default`
+  }
+
+  function handle_mouse_leave() {
+    // Reset drag state if mouse leaves plot area
+    if (drag_start_coords) handle_mouse_up(new MouseEvent(`mouseup`)) // Simulate mouseup
+    hovered = false
+    tooltip_point = null
+  }
+
+  function handle_double_click() {
+    // Reset zoom/pan to initial ranges
+    current_x_range = [...initial_x_range]
+    current_y_range = [...initial_y_range]
+  }
+
+  // --- Tooltip Logic (extracted to function) ---
+
   function on_mouse_move(evt: MouseEvent) {
     hovered = true
 
@@ -421,9 +560,11 @@
     const mouse_y = y_scale_fn.invert(mouse_y_rel)
 
     // Find closest point to mouse
-    let closest_point = null
+    // Internal closest point can hold extra props
+    let closest_point_internal: InternalPoint | null = null
     let min_distance = Infinity
-    let closest_series = null
+    // Type needs to match the complex return type of filtered_series derived
+    let closest_series: (DataSeries & { filtered_data: Point[] }) | null = null
 
     for (const series_data of filtered_series) {
       if (!series_data?.filtered_data) continue
@@ -438,30 +579,45 @@
 
         if (distance < min_distance) {
           min_distance = distance
-          closest_point = point
+          closest_point_internal = point
           closest_series = series_data
         }
       }
     }
 
-    if (closest_point && closest_series) {
-      tooltip_point = closest_point
-      change({ ...closest_point, series: closest_series })
+    if (closest_point_internal && closest_series) {
+      // Cast to Point for the tooltip prop
+      tooltip_point = closest_point_internal // Already Point-like
+      // Construct object matching change signature
+      const { x, y, metadata } = closest_point_internal
+      // Cast internal point properties to match expected Point structure for change prop
+      change({
+        x,
+        y,
+        metadata: metadata as Record<string, unknown> | undefined,
+        series: closest_series,
+      })
     }
   }
 
-  function on_mouse_leave() {
-    hovered = false
-    tooltip_point = null
+  function find_closest_point(evt: MouseEvent) {
+    const coords = get_relative_coords(evt)
+    if (!coords) return
+    on_mouse_move(evt) // Call the original logic
   }
 </script>
 
 <div class="scatter" bind:clientWidth={width} bind:clientHeight={height} {style}>
   {#if width && height}
+    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
     <svg
       onmouseenter={() => (hovered = true)}
-      onmousemove={on_mouse_move}
-      onmouseleave={on_mouse_leave}
+      onmousedown={handle_mouse_down}
+      onmousemove={handle_mouse_move}
+      onmouseup={handle_mouse_up}
+      onmouseleave={handle_mouse_leave}
+      ondblclick={handle_double_click}
+      style:cursor="crosshair"
       role="img"
     >
       <!-- Zero lines -->
@@ -491,11 +647,12 @@
       <!-- Lines -->
       {#if markers?.includes(`line`)}
         {#each filtered_series ?? [] as series, series_idx (series_idx)}
+          {@const first_point = series.filtered_data?.[0] as InternalPoint}
           {@const series_color =
-            series.filtered_data?.[0]?.color_value !== undefined
-              ? color_scale_fn(series.filtered_data[0].color_value)
+            first_point?.color_value != null
+              ? color_scale_fn(first_point.color_value)
               : typeof series?.point_style === `object` && series?.point_style?.fill
-                ? series.point_style.fill
+                ? (series.point_style.fill as string) // Needs casting
                 : `rgba(255, 255, 255, 0.5)`}
 
           <Line
@@ -519,11 +676,9 @@
       <!-- Points -->
       {#if markers?.includes(`points`)}
         {#each filtered_series ?? [] as series, series_idx (series_idx)}
-          {#each series?.filtered_data ?? [] as point, point_idx (point_idx)}
+          {#each (series?.filtered_data ?? []) as InternalPoint[] as point, point_idx (point_idx)}
             {@const point_color =
-              point.color_value !== undefined
-                ? color_scale_fn(point.color_value)
-                : undefined}
+              point.color_value != null ? color_scale_fn(point.color_value) : undefined}
 
             <ScatterPoint
               x={x_format?.startsWith(`%`)
@@ -532,7 +687,7 @@
               y={y_scale_fn(point.y)}
               style={{
                 ...(point.point_style ?? {}),
-                fill: point_color ?? point.point_style?.fill,
+                fill: point_color ?? (point?.point_style?.fill as string | undefined),
               }}
               hover={point.point_hover ?? {}}
               label={point.point_label ?? {}}
@@ -638,13 +793,30 @@
         <circle {cx} {cy} r="5" fill="orange" />
         <foreignObject x={cx + 5} y={cy}>
           {#if tooltip}
-            {@render tooltip({ x, y, cx, cy, x_formatted, y_formatted, metadata })}
+            {@render tooltip({
+              x,
+              y,
+              cx,
+              cy,
+              x_formatted,
+              y_formatted,
+              metadata: metadata as Record<string, unknown> | undefined,
+            })}
           {:else}
             <div class="default-tooltip">
               x: {x_formatted}, y: {y_formatted}
             </div>
           {/if}
         </foreignObject>
+      {/if}
+
+      <!-- Zoom Selection Rectangle -->
+      {#if drag_start_coords && drag_current_coords}
+        {@const x = Math.min(drag_start_coords.x, drag_current_coords.x)}
+        {@const y = Math.min(drag_start_coords.y, drag_current_coords.y)}
+        {@const rect_width = Math.abs(drag_start_coords.x - drag_current_coords.x)}
+        {@const rect_height = Math.abs(drag_start_coords.y - drag_current_coords.y)}
+        <rect class="zoom-rect" {x} {y} width={rect_width} height={rect_height} />
       {/if}
     </svg>
   {/if}
@@ -694,5 +866,11 @@
     /* Ensure background fits content width */
     width: var(--esp-tooltip-width, max-content);
     box-sizing: border-box;
+  }
+  .zoom-rect {
+    fill: var(--esp-zoom-rect-fill, rgba(100, 100, 255, 0.2));
+    stroke: var(--esp-zoom-rect-stroke, rgba(100, 100, 255, 0.8));
+    stroke-width: var(--esp-zoom-rect-stroke-width, 1);
+    pointer-events: none; /* Prevent rect from interfering with mouse events */
   }
 </style>

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -113,6 +113,10 @@
       .flatMap(({ x: xs, y: ys }) => xs.map((x, idx) => ({ x, y: ys[idx] }))),
   )
 
+  // Calculate plot area center coordinates
+  let plot_center_x = $derived(padding.l + (width - padding.r - padding.l) / 2)
+  let plot_center_y = $derived(padding.t + (height - padding.b - padding.t) / 2)
+
   // Compute data color values for color scaling
   let all_color_values = $derived(
     series
@@ -534,6 +538,8 @@
               label={point.point_label ?? {}}
               offset={point.point_offset ?? { x: 0, y: 0 }}
               tween_duration={point.point_tween_duration ?? 600}
+              origin_x={plot_center_x}
+              origin_y={plot_center_y}
             />
           {/each}
         {/each}

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -401,7 +401,7 @@
   }
 
   function on_mouse_move(evt: MouseEvent) {
-    if (!tooltip) return
+    hovered = true
 
     const svg_box = (evt.currentTarget as SVGElement)?.getBoundingClientRect()
     if (!svg_box) return
@@ -454,7 +454,12 @@
 
 <div class="scatter" bind:clientWidth={width} bind:clientHeight={height} {style}>
   {#if width && height}
-    <svg onmousemove={on_mouse_move} onmouseleave={on_mouse_leave} role="img">
+    <svg
+      onmouseenter={() => (hovered = true)}
+      onmousemove={on_mouse_move}
+      onmouseleave={on_mouse_leave}
+      role="img"
+    >
       <!-- Zero lines -->
       {#if show_zero_lines}
         {#if x_min <= 0 && x_max >= 0}
@@ -629,7 +634,7 @@
           {#if tooltip}
             {@render tooltip({ x, y, cx, cy, x_formatted, y_formatted, metadata })}
           {:else}
-            <div style="white-space: nowrap;">
+            <div class="default-tooltip">
               x: {x_formatted}, y: {y_formatted}
             </div>
           {/if}
@@ -673,5 +678,15 @@
   }
   text.label {
     text-anchor: middle;
+  }
+  .default-tooltip {
+    background: var(--esp-tooltip-bg, rgba(0, 0, 0, 0.7));
+    color: var(--esp-tooltip-color, white);
+    padding: var(--esp-tooltip-padding, 5px);
+    border-radius: var(--esp-tooltip-border-radius, 3px);
+    font-size: var(--esp-tooltip-font-size, 0.8em);
+    /* Ensure background fits content width */
+    width: var(--esp-tooltip-width, max-content);
+    box-sizing: border-box;
   }
 </style>

--- a/src/lib/plot/ScatterPoint.svelte
+++ b/src/lib/plot/ScatterPoint.svelte
@@ -15,6 +15,8 @@
     label?: LabelStyle
     offset?: Point[`offset`]
     tween_duration?: number
+    origin_x?: number
+    origin_y?: number
   }
 
   let {
@@ -25,6 +27,8 @@
     label = {},
     offset = { x: 0, y: 0 },
     tween_duration = 600,
+    origin_x = 0,
+    origin_y = 0,
   }: Props = $props()
 
   const {
@@ -37,14 +41,12 @@
     marker_type = `circle`,
     marker_size = null, // If null, derive from radius
   } = style
-
   const {
     enabled: hover_enabled = true,
     scale: hover_scale = 1.5,
     stroke: hover_stroke = `white`,
     stroke_width: hover_stroke_width = 2,
   } = hover
-
   const {
     text = ``,
     offset_x = 5,
@@ -81,8 +83,8 @@
   let marker_path_string = $derived.by(get_symbol_path)
 
   const tween_params = { duration: tween_duration, easing: cubicOut }
-  const tweened_x = new Tween(0, tween_params)
-  const tweened_y = new Tween(0, tween_params)
+  const tweened_x = new Tween(origin_x, tween_params)
+  const tweened_y = new Tween(origin_y, tween_params)
 
   $effect.pre(() => {
     tweened_x.target = x + offset.x

--- a/src/routes/(demos)/scatter-plot/+page.md
+++ b/src/routes/(demos)/scatter-plot/+page.md
@@ -467,7 +467,7 @@ Using time data on the x-axis with custom formatting:
     series={time_series}
     markers="line+points"
     x_format={date_format}
-    y_format={y_format}
+    {y_format}
     x_ticks={-7}
     y_ticks={5}
     x_label="Date"
@@ -1169,7 +1169,7 @@ This example demonstrates how to use `color_values` to apply color mapping to po
       y_label="Y Position"
       markers="points"
       color_scheme={selected_scheme}
-      color_scale_type={color_scale_type}
+      {color_scale_type}
       style="height: 300px; width: 100%;"
     >
       {#snippet tooltip({ x, y, metadata })}

--- a/src/routes/(demos)/scatter-plot/+page.md
+++ b/src/routes/(demos)/scatter-plot/+page.md
@@ -1182,3 +1182,102 @@ This example demonstrates how to use `color_values` to apply color mapping to po
   {/key}
 </div>
 ```
+
+## Automatic Color Bar Placement
+
+This example demonstrates how the color bar automatically positions itself in one of the four corners (top-left, top-right, bottom-left, bottom-right) based on where the data points are least dense. Use the sliders to adjust the number of points generated in each quadrant and observe how the color bar moves to avoid overlapping the data.
+
+```svelte example stackblitz
+<script>
+  import { ScatterPlot } from '$lib'
+
+  // State for controlling point density in each quadrant
+  let density_top_left = $state(10);
+  let density_top_right = $state(50);
+  let density_bottom_left = $state(10);
+  let density_bottom_right = $state(10);
+
+  // Function to generate points within a specific quadrant
+  const generate_quadrant_points = (count, x_range, y_range) => {
+    const points = [];
+    for (let i = 0; i < count; i++) {
+      points.push({
+        x: x_range[0] + Math.random() * (x_range[1] - x_range[0]),
+        y: y_range[0] + Math.random() * (y_range[1] - y_range[0]),
+        // Assign a color value (e.g., based on distance from origin)
+        color_value: Math.sqrt(
+          Math.pow(x_range[0] + (x_range[1] - x_range[0]) / 2, 2) +
+          Math.pow(y_range[0] + (y_range[1] - y_range[0]) / 2, 2)
+        ) * Math.random() * 2 // Add some variation
+      });
+    }
+    return points;
+  };
+
+  // Reactive generation of plot data based on densities
+  let plot_series = $derived(() => {
+    const plot_width = 100;
+    const plot_height = 100;
+    const center_x = plot_width / 2;
+    const center_y = plot_height / 2;
+
+    const tl_points = generate_quadrant_points(density_top_left, [0, center_x], [0, center_y]);
+    const tr_points = generate_quadrant_points(density_top_right, [center_x, plot_width], [0, center_y]);
+    const bl_points = generate_quadrant_points(density_bottom_left, [0, center_x], [center_y, plot_height]);
+    const br_points = generate_quadrant_points(density_bottom_right, [center_x, plot_width], [center_y, plot_height]);
+
+    const all_points = [...tl_points, ...tr_points, ...bl_points, ...br_points];
+
+    return [{
+      x: all_points.map(p => p.x),
+      y: all_points.map(p => p.y),
+      color_values: all_points.map(p => p.color_value),
+      point_style: {
+        radius: 5,
+        stroke: 'white',
+        stroke_width: 0.5
+      }
+    }];
+  });
+
+  // Style for sliders
+  const slider_style = 'width: 100px; margin-left: 0.5em;';
+</script>
+
+<div>
+  <div style="display: flex; flex-wrap: wrap; gap: 1.5em; margin-bottom: 1em; justify-content: center;">
+    <label>Bottom-Left: {density_top_left}
+      <input type="range" min="0" max="100" bind:value={density_top_left} style={slider_style} />
+    </label>
+    <label>Bottom-Right: {density_top_right}
+      <input type="range" min="0" max="100" bind:value={density_top_right} style={slider_style} />
+    </label>
+    <label>Top-Left: {density_bottom_left}
+      <input type="range" min="0" max="100" bind:value={density_bottom_left} style={slider_style} />
+    </label>
+    <label>Top-Right: {density_bottom_right}
+      <input type="range" min="0" max="100" bind:value={density_bottom_right} style={slider_style} />
+    </label>
+  </div>
+
+  <ScatterPlot
+    series={plot_series()}
+    x_label="X Position"
+    y_label="Y Position"
+    x_lim={[0, 100]}
+    y_lim={[0, 100]}
+    markers="points"
+    color_scheme="turbo"
+    show_color_bar={true}
+    color_bar_label="Value"
+    style="height: 450px; width: 100%;"
+  >
+    {#snippet tooltip({ x, y, metadata, color_value })}
+      <div style="white-space: nowrap; padding: 0.25em; background: rgba(0,0,0,0.7); color: white;">
+        Point ({x.toFixed(1)}, {y.toFixed(1)})<br/>
+        Value: {color_value?.toFixed(2)}
+      </div>
+    {/snippet}
+  </ScatterPlot>
+</div>
+```

--- a/src/routes/scatter-plot-e2e/+page.svelte
+++ b/src/routes/scatter-plot-e2e/+page.svelte
@@ -148,6 +148,22 @@
       stroke_width: 1,
     },
   }
+
+  // === Custom Tooltip Data ===
+  const custom_tooltip_data = {
+    x: [1, 2, 3],
+    y: [5, 8, 6],
+    metadata: [{ info: `Point A` }, { info: `Point B` }, { info: `Point C` }],
+    point_style: { fill: `purple`, radius: 6 },
+  }
+
+  // === Bind Hovered Data ===
+  let is_plot_hovered = $state(false)
+  const bind_hovered_data = {
+    x: [10, 20, 30],
+    y: [15, 25, 10],
+    point_style: { fill: `orange`, radius: 5 },
+  }
 </script>
 
 <div class="demo-container">
@@ -324,6 +340,32 @@
       </div>
     </div>
   </section>
+
+  <section class="demo-section" id="custom-tooltip">
+    <h2>Custom Tooltip Example</h2>
+    <div class="demo-plot">
+      <ScatterPlot series={[custom_tooltip_data]} markers="points">
+        {#snippet tooltip(props)}
+          <div class="custom-tooltip">
+            Point Info: <strong>{props.metadata?.info}</strong><br />
+            Coords: ({props.x_formatted}, {props.y_formatted})
+          </div>
+        {/snippet}
+      </ScatterPlot>
+    </div>
+  </section>
+
+  <section class="demo-section" id="bind-hovered">
+    <h2>bind:hovered Example</h2>
+    <p>Plot is currently hovered: <strong id="hover-status">{is_plot_hovered}</strong></p>
+    <div class="demo-plot">
+      <ScatterPlot
+        series={[bind_hovered_data]}
+        markers="points"
+        bind:hovered={is_plot_hovered}
+      />
+    </div>
+  </section>
 </div>
 
 <style>
@@ -357,5 +399,13 @@
   :is(h1, h2, h3) {
     text-align: center;
     margin-top: 0;
+  }
+
+  .custom-tooltip {
+    background: lightblue;
+    color: black;
+    padding: 8px;
+    border: 1px solid blue;
+    border-radius: 4px;
   }
 </style>

--- a/tests/scatter-plot.test.ts
+++ b/tests/scatter-plot.test.ts
@@ -1,219 +1,242 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Locator, type Page } from '@playwright/test'
 
 test.describe(`ScatterPlot Component Tests`, () => {
-  test(`renders basic scatter plot with default settings`, async ({ page }) => {
-    // Navigate to combined page
+  // Navigate to the page before each test
+  test.beforeEach(async ({ page }) => {
     await page.goto(`/scatter-plot-e2e`, { waitUntil: `networkidle` })
+  })
 
+  test(`renders basic scatter plot with default settings`, async ({ page }) => {
     // Verify basic example is rendered
-    const section = await page.$(`#basic-example`)
-    expect(section).not.toBeNull()
+    const section = page.locator(`#basic-example`)
+    await expect(section).toBeVisible()
 
-    // Verify scatter plot is rendered (using non-null assertion since we checked above)
-    const scatter_plot = await section!.$(`.scatter`)
-    expect(scatter_plot).not.toBeNull()
+    // Verify scatter plot is rendered
+    const scatter_plot = section.locator(`.scatter`)
+    await expect(scatter_plot).toBeVisible()
 
-    // Check if SVG is present (using non-null assertion since we checked above)
-    const svg = await scatter_plot!.$(`svg`)
-    expect(svg).not.toBeNull()
+    // Check if SVG is present
+    const svg = scatter_plot.locator(`svg`)
+    await expect(svg).toBeVisible()
   })
 
   test(`handles mouse interactions correctly`, async ({ page }) => {
-    await page.goto(`/scatter-plot-e2e`, { waitUntil: `networkidle` })
+    const scatter_plot = page.locator(`#basic-example .scatter`)
+    await expect(scatter_plot).toBeVisible()
 
-    // Locate the basic scatter plot
-    const section = await page.$(`#basic-example`)
-    expect(section).not.toBeNull()
+    // Hover over the scatter plot - just verify this doesn't cause errors
+    await scatter_plot.hover({ position: { x: 200, y: 150 } })
 
-    const scatter_plot = await section!.$(`.scatter`)
-    expect(scatter_plot).not.toBeNull()
-
-    // Only proceed with hover if the element exists
-    if (scatter_plot) {
-      // Hover over the scatter plot - just verify this doesn't cause errors
-      await scatter_plot.hover({ position: { x: 200, y: 150 } })
-
-      // Move mouse out
-      await page.mouse.move(0, 0)
-    }
+    // Move mouse out
+    await page.mouse.move(0, 0)
   })
 
   test(`displays correct axis labels and ticks`, async ({ page }) => {
-    await page.goto(`/scatter-plot-e2e`, { waitUntil: `networkidle` })
+    const scatter_plot = page.locator(`#basic-example .scatter`)
+    await expect(scatter_plot).toBeVisible()
 
-    // Get the basic example
-    const section = await page.$(`#basic-example`)
-    expect(section).not.toBeNull()
-
-    const scatter_plot = await section!.$(`.scatter`)
-    expect(scatter_plot).not.toBeNull()
-
-    // Check x-axis label (using non-null assertion since we checked above)
-    const x_axis_label = await scatter_plot!.$(`text.label.x`)
-    expect(x_axis_label).not.toBeNull()
-
-    // Check y-axis label
-    const y_axis_label = await scatter_plot!.$(`text.label.y`)
-    expect(y_axis_label).not.toBeNull()
+    // Check axis labels
+    await expect(scatter_plot.locator(`text.label.x`)).toBeVisible()
+    await expect(scatter_plot.locator(`text.label.y`)).toBeVisible()
 
     // Check for tick marks
-    const x_ticks = await scatter_plot!.$$(`g.x-axis .tick`)
-    expect(x_ticks.length).toBeGreaterThan(0)
-
-    const y_ticks = await scatter_plot!.$$(`g.y-axis .tick`)
-    expect(y_ticks.length).toBeGreaterThan(0)
+    expect(
+      await scatter_plot.locator(`g.x-axis .tick`).count(),
+    ).toBeGreaterThan(0)
+    expect(
+      await scatter_plot.locator(`g.y-axis .tick`).count(),
+    ).toBeGreaterThan(0)
   })
 
   test(`properly renders different marker types`, async ({ page }) => {
-    await page.goto(`/scatter-plot-e2e`, { waitUntil: `networkidle` })
+    const section = page.locator(`#marker-types`)
+    await expect(section).toBeVisible()
 
-    // Go to the marker types section
-    const section = await page.$(`#marker-types`)
-    expect(section).not.toBeNull()
+    // Check points-only plot
+    const points_plot = section.locator(`#points-only .scatter`)
+    await expect(points_plot).toBeVisible()
+    expect(await points_plot.locator(`.marker`).count()).toBeGreaterThan(0)
 
-    // Get the points-only plot
-    const points_plot = await section!.$(`#points-only .scatter`)
-    expect(points_plot).not.toBeNull()
+    // Check line-only plot (existence is enough)
+    const line_plot = section.locator(`#line-only .scatter`)
+    await expect(line_plot).toBeVisible()
 
-    // Check that scatter points are rendered
-    const scatter_points = await points_plot!.$$(`.marker`)
-    expect(scatter_points.length).toBeGreaterThan(0)
-
-    // Get the line-only plot
-    const line_plot = await section!.$(`#line-only .scatter`)
-    expect(line_plot).not.toBeNull()
-
-    // Get the line+points plot
-    const line_points_plot = await section!.$(`#line-points .scatter`)
-    expect(line_points_plot).not.toBeNull()
+    // Check line+points plot (existence is enough)
+    const line_points_plot = section.locator(`#line-points .scatter`)
+    await expect(line_points_plot).toBeVisible()
   })
 
   test(`scales correctly with different data ranges`, async ({ page }) => {
-    await page.goto(`/scatter-plot-e2e`, { waitUntil: `networkidle` })
+    const section = page.locator(`#range-test`)
+    await expect(section).toBeVisible()
 
-    // Go to the range test section
-    const section = await page.$(`#range-test`)
-    expect(section).not.toBeNull()
+    // Check wide range plot
+    const wide_range_plot = section.locator(`#wide-range .scatter`)
+    await expect(wide_range_plot).toBeVisible()
+    expect(await wide_range_plot.locator(`.marker`).count()).toBeGreaterThan(0)
 
-    // Get the wide range plot
-    const wide_range_plot = await section!.$(`#wide-range .scatter`)
-    expect(wide_range_plot).not.toBeNull()
-
-    // Check that points are drawn within the viewable area
-    const wide_range_points = await wide_range_plot!.$$(`.marker`)
-    expect(wide_range_points.length).toBeGreaterThan(0)
-
-    // Get the small range plot
-    const small_range_plot = await section!.$(`#small-range .scatter`)
-    expect(small_range_plot).not.toBeNull()
-
-    // Check that points are drawn within the viewable area
-    const small_range_points = await small_range_plot!.$$(`.marker`)
-    expect(small_range_points.length).toBeGreaterThan(0)
+    // Check small range plot
+    const small_range_plot = section.locator(`#small-range .scatter`)
+    await expect(small_range_plot).toBeVisible()
+    expect(await small_range_plot.locator(`.marker`).count()).toBeGreaterThan(0)
   })
 
   test(`handles logarithmic scales correctly`, async ({ page }) => {
-    await page.goto(`/scatter-plot-e2e`, { waitUntil: `networkidle` })
+    const section = page.locator(`#log-scale`)
+    await expect(section).toBeVisible()
 
-    // Go to the log scale section
-    const section = await page.$(`#log-scale`)
-    expect(section).not.toBeNull()
+    // Check log-y plot
+    const log_y_plot = section.locator(`#log-y .scatter`)
+    await expect(log_y_plot).toBeVisible()
+    expect(await log_y_plot.locator(`g.y-axis .tick`).count()).toBeGreaterThan(
+      0,
+    )
 
-    // Get the log-y plot
-    const log_y_plot = await section!.$(`#log-y .scatter`)
-    expect(log_y_plot).not.toBeNull()
-
-    // Verify that log scale ticks are displayed for y-axis
-    const y_ticks = await log_y_plot!.$$(`g.y-axis .tick`)
-    expect(y_ticks.length).toBeGreaterThan(0)
-
-    // Get the log-x plot
-    const log_x_plot = await section!.$(`#log-x .scatter`)
-    expect(log_x_plot).not.toBeNull()
-
-    // Verify that log scale ticks are displayed for x-axis
-    const x_ticks = await log_x_plot!.$$(`g.x-axis .tick`)
-    expect(x_ticks.length).toBeGreaterThan(0)
+    // Check log-x plot
+    const log_x_plot = section.locator(`#log-x .scatter`)
+    await expect(log_x_plot).toBeVisible()
+    expect(await log_x_plot.locator(`g.x-axis .tick`).count()).toBeGreaterThan(
+      0,
+    )
   })
 
   test(`custom styling is applied correctly`, async ({ page }) => {
-    await page.goto(`/scatter-plot-e2e`, { waitUntil: `networkidle` })
+    const section = page.locator(`#custom-style`)
+    await expect(section).toBeVisible()
 
-    // Go to the custom style section
-    const section = await page.$(`#custom-style`)
-    expect(section).not.toBeNull()
+    // Check rainbow points plot
+    const rainbow_plot = section.locator(`#rainbow-points .scatter`)
+    await expect(rainbow_plot).toBeVisible()
+    expect(await rainbow_plot.locator(`.marker`).count()).toBeGreaterThan(0)
 
-    // Get the rainbow points plot
-    const rainbow_plot = await section!.$(`#rainbow-points .scatter`)
-    expect(rainbow_plot).not.toBeNull()
-
-    // Check if points have custom colors (rainbow pattern)
-    const rainbow_markers = await rainbow_plot!.$$(`.marker`)
-    expect(rainbow_markers.length).toBeGreaterThan(0)
-
-    // Get the multi-series plot
-    const multi_series_plot = await section!.$(`#multi-series .scatter`)
-    expect(multi_series_plot).not.toBeNull()
-
-    // Check if multiple series are rendered
-    const multi_series_markers = await multi_series_plot!.$$(`.marker`)
-    expect(multi_series_markers.length).toBeGreaterThan(0)
+    // Check multi-series plot
+    const multi_series_plot = section.locator(`#multi-series .scatter`)
+    await expect(multi_series_plot).toBeVisible()
+    expect(await multi_series_plot.locator(`.marker`).count()).toBeGreaterThan(
+      0,
+    )
   })
+
+  // Helper function to click radio buttons reliably
+  const click_radio = async (page: Page, selector: string): Promise<void> => {
+    await page.evaluate((sel) => {
+      const radio = document.querySelector(sel) as HTMLInputElement
+      if (radio) radio.click()
+    }, selector)
+  }
 
   test(`handles color scaling with both linear and log modes`, async ({
     page,
   }) => {
-    await page.goto(`/scatter-plot-e2e`, { waitUntil: `networkidle` })
+    const section = page.locator(`#color-scale`)
+    await expect(section).toBeVisible()
 
-    // Go to the color scale section
-    const section = await page.$(`#color-scale`)
-    expect(section).not.toBeNull()
+    const color_scale_plot = section.locator(`#color-scale-toggle .scatter`)
+    await expect(color_scale_plot).toBeVisible()
 
-    // Get the color scale plot
-    const color_scale_plot = await section!.$(`#color-scale-toggle .scatter`)
-    expect(color_scale_plot).not.toBeNull()
+    const linear_radio = section.locator(`input[value="linear"]`)
+    const log_radio = section.locator(`input[value="log"]`)
 
-    // Check initial state - should be linear mode by default
-    const linear_radio = await section!.$(`input[value="linear"]`)
-    expect(await linear_radio?.isChecked()).toBe(true)
+    // Check initial state (linear) and points
+    await expect(linear_radio).toBeChecked()
+    expect(await color_scale_plot.locator(`.marker`).count()).toBeGreaterThan(0)
 
-    // Check that points are rendered
-    const points = await color_scale_plot!.$$(`.marker`)
-    expect(points.length).toBeGreaterThan(0)
+    // Switch to log mode and check state
+    await click_radio(page, `#color-scale input[value="log"]`)
+    await expect(log_radio).toBeChecked()
+    await expect(linear_radio).not.toBeChecked()
+    expect(await color_scale_plot.locator(`.marker`).count()).toBeGreaterThan(0) // Points should still render
 
-    // Switch to log mode
-    const log_radio = await section!.$(`input[value="log"]`)
-    expect(log_radio).not.toBeNull()
+    // Switch back to linear mode
+    await click_radio(page, `#color-scale input[value="linear"]`)
+    await expect(linear_radio).toBeChecked()
+  })
 
-    // We need to force a click event since radio button might not be fully visible
-    await page.evaluate(() => {
-      // Use querySelector to find the log radio button and trigger a click
-      const logRadio = document.querySelector(
-        `#color-scale input[value="log"]`,
-      ) as HTMLInputElement
-      if (logRadio) {
-        logRadio.click()
-      }
-    })
+  // Helper to check tooltip visibility and interaction
+  const check_tooltip = async (
+    page: Page,
+    plot_locator: Locator,
+    tooltip_locator: Locator,
+    hover_position: { x: number; y: number },
+    expected_text?: string | RegExp,
+  ): Promise<void> => {
+    const highlight_circle = plot_locator.locator(`circle[fill="orange"]`)
+    const svg = plot_locator.locator(`svg`)
 
-    // Verify log mode is active
-    expect(await log_radio?.isChecked()).toBe(true)
-    expect(await linear_radio?.isChecked()).toBe(false)
+    // Initial state
+    await expect(tooltip_locator).not.toBeVisible()
+    await expect(highlight_circle).not.toBeVisible()
 
-    // Check that points are still rendered after switching modes
-    const points_after_switch = await color_scale_plot!.$$(`.marker`)
-    expect(points_after_switch.length).toBeGreaterThan(0)
+    // Hover to show tooltip
+    await svg.hover({ position: hover_position, force: true })
+    await page.waitForTimeout(100) // Allow time for transitions/updates
 
-    // Switch back to linear mode using the same technique
-    await page.evaluate(() => {
-      const linearRadio = document.querySelector(
-        `#color-scale input[value="linear"]`,
-      ) as HTMLInputElement
-      if (linearRadio) {
-        linearRadio.click()
-      }
-    })
+    // Verify tooltip and highlight are visible
+    await expect(highlight_circle).toBeVisible()
+    await expect(tooltip_locator).toBeVisible()
+    if (expected_text) {
+      await expect(tooltip_locator).toHaveText(expected_text)
+    }
 
-    expect(await linear_radio?.isChecked()).toBe(true)
+    // Move mouse away
+    await page.mouse.move(0, 0)
+    await page.waitForTimeout(100)
+
+    // Verify tooltip and highlight are hidden
+    await expect(tooltip_locator).not.toBeVisible()
+    await expect(highlight_circle).not.toBeVisible()
+  }
+
+  test(`tooltip appears on hover and disappears on mouse leave`, async ({
+    page,
+  }) => {
+    const plot_locator = page.locator(`#basic-example .scatter`)
+    const tooltip_locator = plot_locator.locator(`.default-tooltip`)
+
+    await check_tooltip(
+      page,
+      plot_locator,
+      tooltip_locator,
+      { x: 70, y: 200 }, // Approx position for first point (1, 10)
+      /x: [-+]?\d*\.?\d+, y: [-+]?\d*\.?\d+/, // Default format check
+    )
+  })
+
+  test(`custom tooltip snippet works correctly`, async ({ page }) => {
+    const plot_locator = page.locator(`#custom-tooltip .scatter`)
+    const tooltip_locator = plot_locator.locator(`.custom-tooltip`)
+
+    await check_tooltip(
+      page,
+      plot_locator,
+      tooltip_locator,
+      { x: 150, y: 100 }, // Approx position for second point (2, 8)
+    )
+    // Specific text checks after hover confirmation
+    const svg = plot_locator.locator(`svg`)
+    await svg.hover({ position: { x: 150, y: 100 }, force: true }) // Re-hover to check text
+    await page.waitForTimeout(100) // Allow time for transitions/updates
+    await expect(tooltip_locator).toContainText(`Point Info: Point B`)
+    await expect(tooltip_locator).toContainText(`Coords: (2, 8)`)
+    await page.mouse.move(0, 0) // Move away finally
+  })
+
+  test(`bind:hovered works correctly`, async ({ page }) => {
+    const section = page.locator(`#bind-hovered`)
+    const svg = section.locator(`.scatter svg`)
+    const hover_status = page.locator(`#hover-status`)
+
+    // Initial state: not hovered
+    await expect(hover_status).toHaveText(`false`)
+
+    // Hover over the plot
+    await svg.hover({ position: { x: 100, y: 100 }, force: true })
+    await page.waitForTimeout(50) // Allow time for transitions/updates
+    await expect(hover_status).toHaveText(`true`) // Check immediately after hover
+
+    // Move mouse away
+    await page.mouse.move(0, 0)
+    await page.waitForTimeout(50) // Allow time for transitions/updates
+    await expect(hover_status).toHaveText(`false`) // Check immediately after moving away
   })
 })

--- a/tests/unit/Line.test.ts
+++ b/tests/unit/Line.test.ts
@@ -1,0 +1,175 @@
+import { Line } from '$lib'
+import { mount } from 'svelte'
+import { beforeEach, describe, expect, test } from 'vitest'
+
+describe(`Line`, () => {
+  // Setup container
+  const container_style = `width: 800px; height: 600px; position: relative;`
+  let target_div: HTMLDivElement
+
+  beforeEach(() => {
+    // Efficiently reset and recreate the target div
+    document.body.innerHTML = ``
+    target_div = document.createElement(`div`)
+    target_div.setAttribute(`style`, container_style)
+    document.body.appendChild(target_div)
+  })
+
+  // Parameterized test for default and custom styles
+  test.each([
+    {
+      name: `default styles`,
+      props: {}, // Relies on component defaults
+      expected_line: {
+        stroke: `rgba(255, 255, 255, 0.5)`,
+        strokeWidth: `2`,
+        fill: `none`,
+      },
+      expected_area: {
+        fill: `rgba(255, 255, 255, 0.1)`,
+        stroke: ``, // Default area_stroke is null -> empty string style
+      },
+    },
+    {
+      name: `custom styles`,
+      props: {
+        line_color: `red`,
+        line_width: 3,
+        area_color: `blue`,
+        area_stroke: `green`,
+      },
+      expected_line: {
+        stroke: `red`,
+        strokeWidth: `3`,
+        fill: `none`,
+      },
+      expected_area: {
+        fill: `blue`,
+        stroke: `green`,
+      },
+    },
+  ])(`renders with $name`, ({ props, expected_line, expected_area }) => {
+    const points: [number, number][] = [
+      [10, 10],
+      [50, 50],
+      [100, 20],
+    ]
+    const origin: [number, number] = [0, 200]
+
+    const component = mount(Line, {
+      target: target_div,
+      props: { points, origin, ...props }, // Spread additional props
+    })
+
+    expect(component).toBeTruthy()
+    const paths = target_div.querySelectorAll(`path`)
+    expect(paths.length).toBe(2)
+
+    const line_path = paths[0]
+    const area_path = paths[1]
+
+    // Assert line styles
+    expect(line_path.getAttribute(`fill`)).toBe(expected_line.fill)
+    expect(line_path.style.stroke).toBe(expected_line.stroke)
+    expect(line_path.style.strokeWidth).toBe(expected_line.strokeWidth)
+
+    // Assert area styles
+    expect(area_path.style.fill).toBe(expected_area.fill)
+    expect(area_path.style.stroke).toBe(expected_area.stroke)
+  })
+
+  test(`calculates line path correctly for 2 and 3 points`, () => {
+    const origin: [number, number] = [0, 100]
+
+    // Test with 3 points (expects curve 'C')
+    const points_3 = [
+      [0, 100],
+      [100, 0],
+      [200, 100],
+    ] as [number, number][]
+    mount(Line, {
+      target: target_div,
+      props: { points: points_3, origin, tween_duration: 0 },
+    })
+    const paths_3 = target_div.querySelectorAll(`path`)
+    expect(paths_3[0].getAttribute(`d`)).toMatch(/^M0,100C.*100,0.*C.*200,100$/)
+
+    // Clean up target before remounting
+    target_div.innerHTML = ``
+
+    // Test with 2 points (expects line 'L')
+    const points_2 = [
+      [0, 100],
+      [100, 0],
+    ] as [number, number][]
+    mount(Line, {
+      target: target_div, // Reuse the cleaned div
+      props: { points: points_2, origin, tween_duration: 0 },
+    })
+    const paths_2 = target_div.querySelectorAll(`path`)
+    expect(paths_2[0].getAttribute(`d`)).toMatch(/^M0,100L100,0$/)
+  })
+
+  test(`calculates area path correctly with 2 points`, () => {
+    const points: [number, number][] = [
+      [0, 50],
+      [100, 0],
+    ]
+    const origin: [number, number] = [0, 100] // Y origin at 100
+
+    mount(Line, {
+      target: target_div,
+      props: { points, origin, tween_duration: 0 },
+    })
+
+    const area_path = target_div.querySelectorAll(`path`)[1]
+    expect(area_path.getAttribute(`d`)).toMatch(/^M0,50L100,0L100,100L0,100Z$/)
+  })
+
+  test(`initializes tweens`, () => {
+    const points: [number, number][] = [
+      [10, 10],
+      [50, 50],
+    ]
+    const origin: [number, number] = [0, 100]
+
+    const component = mount(Line, {
+      target: target_div,
+      props: { points, origin, tween_duration: 100 },
+    })
+
+    expect(component).toBeTruthy() // Verify component mounts
+    const paths = target_div.querySelectorAll(`path`)
+    expect(paths.length).toBe(2) // Check paths exist
+  })
+
+  test(`handles empty points array`, () => {
+    const points: [number, number][] = []
+    const origin: [number, number] = [0, 100]
+
+    mount(Line, {
+      target: target_div,
+      props: { points, origin, tween_duration: 0 },
+    })
+
+    const paths = target_div.querySelectorAll(`path`)
+    expect(paths.length).toBe(2)
+    expect(paths[0].getAttribute(`d`)).toBe(``)
+    expect(paths[1].getAttribute(`d`)).toBe(``)
+  })
+
+  test(`handles single point array`, () => {
+    const points: [number, number][] = [[50, 50]]
+    const origin: [number, number] = [0, 100]
+
+    mount(Line, {
+      target: target_div,
+      props: { points, origin, tween_duration: 0 },
+    })
+
+    const paths = target_div.querySelectorAll(`path`)
+    expect(paths.length).toBe(2)
+    expect(paths[0].getAttribute(`d`)).toMatch(/^M50,50Z?$/)
+    expect(paths[1].getAttribute(`d`)).toMatch(/^M50,50Z?L50,100L50,100Z$/)
+  })
+})

--- a/tests/unit/ScatterPlot.test.ts
+++ b/tests/unit/ScatterPlot.test.ts
@@ -89,25 +89,6 @@ describe(`ScatterPlot`, () => {
     document.body.appendChild(container)
   })
 
-  test(`renders with default props and applies custom style`, () => {
-    // Default props
-    mount(ScatterPlot, { target: document.body })
-
-    let scatter = document.querySelector(`.scatter`)
-    expect(scatter).toBeTruthy()
-    expect(getComputedStyle(scatter!).width).toBe(`100%`)
-
-    document.body.innerHTML = ``
-
-    // Custom style
-    const style = `height: 300px; background: black;`
-    mount(ScatterPlot, { target: document.body, props: { style } })
-
-    scatter = document.querySelector(`.scatter`)
-    expect(scatter).toBeTruthy()
-    expect(scatter!.getAttribute(`style`)).toContain(style)
-  })
-
   test.each([
     {
       name: `basic data`,


### PR DESCRIPTION
- ScatterPlot.svelte add auto-placed ColorBar
- make ScatterPlot.svelte zoomable by dragging across plot area, reset viewport with double click
- tween ScatterPoint.svelte from plot center rather than top-left plot corner, looks better
- ScatterPlot.svelte fix on_mouse_move returning early, b
reaking hover tooltip