### PR TITLE
`ScatterPlot` allow custom tween easing and interpolation functions + fix NaNs in interpolated ScatterPoint coords when tweening between linear/log scaled

### DIFF
--- a/src/lib/plot/ColorScaleSelect.svelte
+++ b/src/lib/plot/ColorScaleSelect.svelte
@@ -37,10 +37,10 @@
 >
   {#snippet children({ option }: { option: string })}
     <ColorBar
-      label={option}
+      title={option}
       color_scale={option}
       tick_labels={0}
-      label_side="left"
+      title_side="left"
       wrapper_style="min-width: 18em;"
       {...cbar_props}
     />

--- a/src/lib/plot/Line.svelte
+++ b/src/lib/plot/Line.svelte
@@ -3,37 +3,31 @@
   import { interpolatePath } from 'd3-interpolate-path'
   import { curveMonotoneX, line } from 'd3-shape'
   import { linear } from 'svelte/easing'
-  import { Tween } from 'svelte/motion'
+  import { Tween, type TweenedOptions } from 'svelte/motion'
 
   interface Props {
+    points: readonly [number, number][]
+    origin: [number, number]
     line_color?: string
     line_width?: number
     area_color?: string
     area_stroke?: string | null
-    tween_duration?: number
-    origin: [number, number]
-    points: [number, number][]
+    line_tween?: TweenedOptions<string>
   }
   let {
+    points,
+    origin = [0, 0],
     line_color = `rgba(255, 255, 255, 0.5)`,
     line_width = 2,
     area_color = `rgba(255, 255, 255, 0.1)`,
     area_stroke = null,
-    tween_duration = 300,
-    origin,
-    points,
+    line_tween = {},
   }: Props = $props()
 
   const lineGenerator = line()
     .x((point) => point[0])
     .y((point) => point[1])
     .curve(curveMonotoneX)
-
-  const tween_params = {
-    duration: tween_duration,
-    easing: linear,
-    interpolate: interpolatePath,
-  }
 
   let [x_min, x_max] = $derived(extent(points.map((p) => p[0])))
   let line_path = $derived(lineGenerator(points) ?? ``)
@@ -42,8 +36,9 @@
     line_path ? `${line_path}L${x_max},${ymin}L${x_min},${ymin}Z` : ``,
   )
 
-  const tweened_line = new Tween(``, tween_params)
-  const tweened_area = new Tween(``, tween_params)
+  const default_tween = { duration: 300, easing: linear, interpolate: interpolatePath }
+  const tweened_line = new Tween(``, { ...default_tween, ...line_tween })
+  const tweened_area = new Tween(``, { ...default_tween, ...line_tween })
 
   $effect.pre(() => {
     tweened_line.target = line_path

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -38,7 +38,7 @@
   import ScatterPoint from './ScatterPoint.svelte'
 
   interface Props {
-    series?: DataSeries[]
+    series?: readonly DataSeries[]
     style?: string
     x_lim?: [number | null, number | null]
     y_lim?: [number | null, number | null]
@@ -82,6 +82,8 @@
     label_placement_config?: Partial<LabelPlacementConfig>
     hover_config?: Partial<HoverConfig>
     legend?: LegendConfig | null // Configuration for the legend
+    point_tween?: TweenedOptions<{ x: number; y: number }>
+    line_tween?: TweenedOptions<string>
   }
   let {
     series = [],
@@ -119,6 +121,8 @@
     label_placement_config = {},
     hover_config = {},
     legend = {}, // Default legend config
+    point_tween,
+    line_tween,
   }: Props = $props()
 
   let width = $state(0)
@@ -347,7 +351,6 @@
             point_hover: process_prop(rest.point_hover, point_idx),
             point_label: process_prop(rest.point_label, point_idx),
             point_offset: process_prop(rest.point_offset, point_idx),
-            point_tween_duration: rest.point_tween_duration,
             series_idx,
             point_idx,
             series_visible: true, // Mark points from visible series
@@ -1131,6 +1134,7 @@
                 line_color={series_color}
                 line_width={1}
                 area_color="transparent"
+                {line_tween}
               />
             {/if}
           </g>
@@ -1176,9 +1180,8 @@
                   hover={point.point_hover ?? {}}
                   label={final_label}
                   offset={point.point_offset ?? { x: 0, y: 0 }}
-                  tween_duration={point.point_tween_duration ?? 600}
-                  origin_x={plot_center_x}
-                  origin_y={plot_center_y}
+                  {point_tween}
+                  origin={{ x: plot_center_x, y: plot_center_y }}
                   --point-fill-color={(color_value != null
                     ? color_scale_fn(color_value)
                     : undefined) ?? point.point_style?.fill}

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -208,23 +208,17 @@
 
   // Store initial ranges and initialize current ranges
   $effect(() => {
-    const new_initial_x = x_range ?? auto_x_range
-    const new_initial_y = y_range ?? auto_y_range
+    const new_init_x = x_range ?? auto_x_range
+    const new_init_y = y_range ?? auto_y_range
 
     // Only update if the initial range fundamentally changes, force type
-    if (
-      new_initial_x[0] !== initial_x_range[0] ||
-      new_initial_x[1] !== initial_x_range[1]
-    ) {
-      initial_x_range = new_initial_x as [number, number]
-      current_x_range = new_initial_x as [number, number]
+    if (new_init_x[0] !== initial_x_range[0] || new_init_x[1] !== initial_x_range[1]) {
+      initial_x_range = new_init_x as [number, number]
+      current_x_range = new_init_x as [number, number]
     }
-    if (
-      new_initial_y[0] !== initial_y_range[0] ||
-      new_initial_y[1] !== initial_y_range[1]
-    ) {
-      initial_y_range = new_initial_y as [number, number]
-      current_y_range = new_initial_y as [number, number]
+    if (new_init_y[0] !== initial_y_range[0] || new_init_y[1] !== initial_y_range[1]) {
+      initial_y_range = new_init_y as [number, number]
+      current_y_range = new_init_y as [number, number]
     }
   })
 
@@ -611,7 +605,7 @@
       if (typeof x_ticks === `number`) {
         count =
           x_ticks < 0
-            ? Math.ceil((x_max - x_min) / Math.abs(x_ticks) / 86400000)
+            ? Math.ceil((x_max - x_min) / Math.abs(x_ticks) / 86_400_000)
             : x_ticks
       } else if (typeof x_ticks === `string`) {
         count = x_ticks === `day` ? 30 : x_ticks === `month` ? 12 : 10

--- a/src/lib/plot/index.ts
+++ b/src/lib/plot/index.ts
@@ -64,13 +64,13 @@ export interface PlotPoint extends Point {
   point_hover?: HoverStyle
   point_label?: LabelStyle
   point_offset?: { x: number; y: number } // Individual point offset (distinct from label offset)
-  point_tween_duration?: number
+  point_tween?: TweenedOptions<{ x: number; y: number }>
 }
 
 // Define the structure for a data series in the plot
 export interface DataSeries {
-  x: number[]
-  y: number[]
+  x: readonly number[]
+  y: readonly number[]
   // Optional marker display type override for this specific series
   markers?: `line` | `points` | `line+points`
   color_values?: (number | null)[] | null
@@ -79,7 +79,7 @@ export interface DataSeries {
   point_hover?: HoverStyle[] | HoverStyle // Can be array or single object
   point_label?: LabelStyle[] | LabelStyle // Can be array or single object
   point_offset?: { x: number; y: number }[] | { x: number; y: number } // Can be array or single object
-  point_tween_duration?: number
+  point_tween?: TweenedOptions<{ x: number; y: number }>
   visible?: boolean // Optional visibility flag
   label?: string // Optional series label for legend
 }

--- a/src/routes/(demos)/color-bar/+page.md
+++ b/src/routes/(demos)/color-bar/+page.md
@@ -17,12 +17,12 @@ Here's a `ColorBar` with tick labels, using the new `tick_align` prop:
 <div style="border: 0.1px dashed white;">
   {#each bars as [color_scale, tick_align, tick_labels, range, align_desc]}
     <ColorBar
-      label="{color_scale}<br>&bull; tick align={align_desc}<br>&bull; range={range}"
+      title="{color_scale}<br>&bull; tick align={align_desc}<br>&bull; range={range}"
       {color_scale}
       {tick_align}
       {tick_labels}
       {range}
-      label_style="white-space: nowrap; padding-right: 1em;"
+      title_style="white-space: nowrap; padding-right: 1em;"
       --cbar-width="100%"
       --cbar-padding="2em"
     />
@@ -41,7 +41,7 @@ You can make fat and skinny bars:
 
 <ColorBar {wrapper_style} style="width: 10em; height: 1ex;" />
 <br />
-<ColorBar label="Viridis" {wrapper_style} style="width: 3em; height: 2em;" />
+<ColorBar title="Viridis" {wrapper_style} style="width: 3em; height: 2em;" />
 <br />
 <ColorBar {wrapper_style} --cbar-width="8em" --cbar-height="2em" />
 ```
@@ -82,7 +82,7 @@ You can make fat and skinny bars:
   <TableInset  style="place-items: center; padding: 2em;">
     <ColorBar
       {color_scale}
-      label={heatmap_key}
+      title={heatmap_key}
       range={heat_range}
       tick_labels={5}
       tick_align="primary"
@@ -103,32 +103,32 @@ You can make fat and skinny bars:
 </style>
 ```
 
-Example demonstrating `label_side` and `tick_align` interaction:
+Example demonstrating `title_side` and `tick_align` interaction:
 
 ```svelte example stackblitz
 <script>
   import { ColorBar } from '$lib'
 
-  const label_sides = [`top`, `bottom`, `left`, `right`]
+  const title_sides = [`top`, `bottom`, `left`, `right`]
   const tick_sides = [`primary`, `secondary`, `inside`]
 </script>
 
 <section>
-  {#each label_sides as label_side, l_idx}
+  {#each title_sides as title_side, l_idx}
     {#each tick_sides as tick_side, t_idx}
       {@const orientation =
-        label_side === `top` || label_side === `bottom` ? `horizontal` : `vertical`}
+        title_side === `top` || title_side === `bottom` ? `horizontal` : `vertical`}
       {@const bar_style = orientation === `horizontal` ? `width: 150px; height: 20px;` : `width: 20px; height: 150px;`}
       {@const num_ticks = l_idx + t_idx + 2}
       {@const current_range = [l_idx * 10, (l_idx + 1) * 10 + t_idx * 20]}
       <div>
-        <code>label={label_side}<br />tick={tick_side}</code>
+        <code>title={title_side}<br />tick={tick_side}</code>
         <ColorBar
-          {label_side}
+          {title_side}
           {tick_side}
           {orientation}
           style={bar_style}
-          label="Label"
+          title="Label"
           tick_labels={num_ticks}
           range={current_range}
           --cbar-tick-overlap-offset="10px"
@@ -162,4 +162,43 @@ Example demonstrating `label_side` and `tick_align` interaction:
     text-align: center;
   }
 </style>
+```
+
+## Date/Time Ranges
+
+You can format tick labels for date/time ranges by providing a D3 format string via the `tick_format` prop. The color bar accepts ranges as milliseconds since the epoch (standard JavaScript `Date.getTime()`).
+
+```svelte example stackblitz
+<script>
+  import { ColorBar } from '$lib'
+
+  // Example date range (e.g., start and end of 2024)
+  const date_range = [
+    new Date(2024, 0, 1).getTime(), // Jan 1, 2024
+    new Date(2024, 11, 31).getTime(), // Dec 31, 2024
+  ]
+</script>
+
+<div style="display: flex; column; gap: 2em; align-items: center;">
+  <ColorBar
+    title="Year 2024 (YYYY-MM-DD)"
+    range={date_range}
+    tick_format="%Y-%m-%d"
+    tick_labels={2} />
+
+  <ColorBar
+    title="Year 2024 (Month Day)"
+    range={date_range}
+    style="width: 500px;"
+    tick_format="%b %d"
+    tick_labels={7} />
+
+  <ColorBar
+    title="Year 2024 (Vertical - Mmm DD, YY)"
+    range={date_range}
+    tick_format="%b %d, '%y"
+    tick_labels={4}
+    orientation="vertical"
+    wrapper_style="height: 200px;" />
+</div>
 ```

--- a/src/routes/test/scatter-plot/+page.svelte
+++ b/src/routes/test/scatter-plot/+page.svelte
@@ -271,6 +271,19 @@
     { x: [1, 2], y: [1, 2], metadata: { label: `Series B` } },
   ]
   const legend_zero_series: DataSeries[] = []
+
+  // === Linear-to-Log Transition Test Data ===
+  let lin_log_y_scale_type = $state<`linear` | `log`>(`linear`)
+  const lin_log_transition_data = {
+    x: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    y: [100, 50, 10, 1, 0.1, 0.01, 0.001, 1e-4, 1e-6, 1e-8], // Include values very close to zero
+    point_style: {
+      fill: `darkcyan`,
+      radius: 5,
+      stroke: `white`,
+      stroke_width: 1,
+    },
+  }
 </script>
 
 <div class="demo-container">
@@ -507,6 +520,37 @@
         <h3>Zero Series - No Legend Expected</h3>
         <ScatterPlot series={legend_zero_series} />
       </div>
+    </div>
+  </section>
+
+  <section class="demo-section" id="lin-log-transition">
+    <h2>Linear-to-Log Scale Transition Test</h2>
+    <p>
+      Test switching between linear and log scales. Values near zero previously caused NaN
+      errors during the tweening animation.
+    </p>
+    <div style="display: flex; justify-content: center; gap: 1em; margin-bottom: 1em;">
+      {#each [`linear`, `log`] as scale_type (scale_type)}
+        <label>
+          <input
+            type="radio"
+            name="lin_log_y_scale_type"
+            value={scale_type}
+            bind:group={lin_log_y_scale_type}
+          />
+          {scale_type} y-axis
+        </label>
+      {/each}
+    </div>
+    <div class="demo-plot" style="height: 400px;">
+      <ScatterPlot
+        series={[lin_log_transition_data]}
+        x_label="X Axis (Linear)"
+        y_label="Y Axis"
+        markers="line+points"
+        y_scale_type={lin_log_y_scale_type}
+        y_lim={lin_log_y_scale_type === `log` ? [1e-9, null] : [null, null]}
+      />
     </div>
   </section>
 </div>

--- a/tests/scatter-plot.test.ts
+++ b/tests/scatter-plot.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Locator, type Page } from '@playwright/test'
 
 test.describe(`ScatterPlot Component Tests`, () => {
-  // Navigate to the page before each test
+  // Navigate to the test page before each test
   test.beforeEach(async ({ page }) => {
     await page.goto(`/test/scatter-plot`, { waitUntil: `load` })
   })
@@ -14,18 +14,18 @@ test.describe(`ScatterPlot Component Tests`, () => {
     const svg = scatter_plot.locator(`svg[role='img']`)
     await expect(svg).toBeVisible()
 
-    // Stricter: Check marker count
+    // Check marker count matches data
     await expect(scatter_plot.locator(`.marker`)).toHaveCount(10) // basic_data has 10 points
 
-    // Stricter: Check default axis labels from test page
+    // Check default axis labels from test page
     await expect(scatter_plot.locator(`text.label.x`)).toHaveText(`X Axis`)
     await expect(scatter_plot.locator(`text.label.y`)).toHaveText(`Y Axis`)
 
-    // Stricter: Check tick counts (Adjusted)
+    // Check tick counts (Adjusted based on d3 default behavior)
     await expect(scatter_plot.locator(`g.x-axis .tick`)).toHaveCount(10)
     await expect(scatter_plot.locator(`g.y-axis .tick`)).toHaveCount(4)
 
-    // Stricter: Check first/last tick text (adjust based on observed defaults)
+    // Check first/last tick text
     await expect(
       scatter_plot.locator(`g.x-axis .tick text`).first(),
     ).toHaveText(`1`)
@@ -36,7 +36,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
       scatter_plot.locator(`g.y-axis .tick text`).first(),
     ).toHaveText(`10`)
     await expect(scatter_plot.locator(`g.y-axis .tick text`).last()).toHaveText(
-      /25\s*/,
+      /25\s*/, // Allow trailing space
     )
   })
 
@@ -44,15 +44,13 @@ test.describe(`ScatterPlot Component Tests`, () => {
     const scatter_plot = page.locator(`#basic-example .scatter`)
     await expect(scatter_plot).toBeVisible()
 
-    // Stricter: Check exact axis labels
     await expect(scatter_plot.locator(`text.label.x`)).toHaveText(`X Axis`)
     await expect(scatter_plot.locator(`text.label.y`)).toHaveText(`Y Axis`)
 
-    // Stricter: Check tick counts (Adjusted)
     await expect(scatter_plot.locator(`g.x-axis .tick`)).toHaveCount(10)
     await expect(scatter_plot.locator(`g.y-axis .tick`)).toHaveCount(4)
 
-    // Commented out brittle first/last tick checks -> Uncommented
+    // Check first/last tick text again for robustness
     await expect(
       scatter_plot.locator(`g.x-axis .tick text`).first(),
     ).toHaveText(`1`)
@@ -63,7 +61,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
       scatter_plot.locator(`g.y-axis .tick text`).first(),
     ).toHaveText(`10`)
     await expect(scatter_plot.locator(`g.y-axis .tick text`).last()).toHaveText(
-      /25\s*/,
+      /25\s*/, // Allow trailing space
     )
   })
 
@@ -74,31 +72,26 @@ test.describe(`ScatterPlot Component Tests`, () => {
     // Check points-only plot
     const points_plot = section.locator(`#points-only .scatter`)
     await expect(points_plot).toBeVisible()
-    // Stricter: Check exact marker count
-    await expect(points_plot.locator(`.marker`)).toHaveCount(10) // points_data has 10 points
+    await expect(points_plot.locator(`.marker`)).toHaveCount(10)
 
     // Check line-only plot
     const line_plot = section.locator(`#line-only .scatter`)
     await expect(line_plot).toBeVisible()
-    // Stricter: Check line path exists and has a 'd' attribute
     await expect(line_plot.locator(`path[fill="none"]`)).toBeVisible()
     await expect(line_plot.locator(`path[fill="none"]`)).toHaveAttribute(
       `d`,
       /M.+/, // Check 'd' attribute starts with 'M' (moveto)
     )
-    // Stricter: Check no markers exist
-    await expect(line_plot.locator(`.marker`)).toHaveCount(0)
+    await expect(line_plot.locator(`.marker`)).toHaveCount(0) // No markers
 
     // Check line+points plot
     const line_points_plot = section.locator(`#line-points .scatter`)
     await expect(line_points_plot).toBeVisible()
-    // Stricter: Check exact marker count
-    await expect(line_points_plot.locator(`.marker`)).toHaveCount(10) // line_points_data has 10 points
-    // Stricter: Check line path exists
+    await expect(line_points_plot.locator(`.marker`)).toHaveCount(10)
     await expect(line_points_plot.locator(`path[fill="none"]`)).toBeVisible()
     await expect(line_points_plot.locator(`path[fill="none"]`)).toHaveAttribute(
       `d`,
-      /M.+/, // Check 'd' attribute starts with 'M' (moveto)
+      /M.+/,
     )
   })
 
@@ -109,10 +102,8 @@ test.describe(`ScatterPlot Component Tests`, () => {
     // Check wide range plot
     const wide_range_plot = section.locator(`#wide-range .scatter`)
     await expect(wide_range_plot).toBeVisible()
-    // Stricter: Check exact marker count
-    await expect(wide_range_plot.locator(`.marker`)).toHaveCount(9) // wide_range_data has 9 points
-    // Stricter: Check axis ticks reflect the range (example: first/last tick)
-    // Remove brittle first/last tick checks after .nice() -> Uncommented
+    await expect(wide_range_plot.locator(`.marker`)).toHaveCount(9)
+    // Check axis ticks reflect the wide range
     await expect(
       wide_range_plot.locator(`g.x-axis .tick text`).first(),
     ).toHaveText(`-1200`)
@@ -121,18 +112,16 @@ test.describe(`ScatterPlot Component Tests`, () => {
     ).toHaveText(`1200`)
     await expect(
       wide_range_plot.locator(`g.y-axis .tick text`).first(),
-    ).toHaveText(/-600\s*/)
+    ).toHaveText(/-600\s*/) // Allow trailing space
     await expect(
       wide_range_plot.locator(`g.y-axis .tick text`).last(),
-    ).toHaveText(/600\s*/)
+    ).toHaveText(/600\s*/) // Allow trailing space
 
     // Check small range plot
     const small_range_plot = section.locator(`#small-range .scatter`)
     await expect(small_range_plot).toBeVisible()
-    // Stricter: Check exact marker count
-    await expect(small_range_plot.locator(`.marker`)).toHaveCount(5) // small_range_data has 5 points
-    // Stricter: Check axis ticks reflect the range (example: first/last tick)
-    // Remove brittle first/last tick checks after .nice() -> Uncommented
+    await expect(small_range_plot.locator(`.marker`)).toHaveCount(5)
+    // Check axis ticks reflect the small range
     await expect(
       small_range_plot.locator(`g.x-axis .tick text`).first(),
     ).toHaveText(`0`)
@@ -144,7 +133,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
     ).toHaveText(`0`)
     await expect(
       small_range_plot.locator(`g.y-axis .tick text`).last(),
-    ).toHaveText(/0\.00006\s*/) // Adjust small y-axis last tick back to float, allow space
+    ).toHaveText(/0\.00006\s*/) // Allow trailing space
   })
 
   test(`handles logarithmic scales correctly`, async ({ page }) => {
@@ -154,28 +143,28 @@ test.describe(`ScatterPlot Component Tests`, () => {
     // Check log-y plot
     const log_y_plot = section.locator(`#log-y .scatter`)
     await expect(log_y_plot).toBeVisible()
-    // Stricter: Check tick count and specific tick values
+    // Check tick count and specific tick values for log y-axis
     await expect(log_y_plot.locator(`g.y-axis .tick`)).toHaveCount(5)
     await expect(log_y_plot.locator(`g.y-axis .tick text`).nth(0)).toHaveText(
-      /^1\s/,
+      /^1\s/, // Allow trailing space
     )
     await expect(log_y_plot.locator(`g.y-axis .tick text`).nth(1)).toHaveText(
-      /10\s*/,
+      /10\s*/, // Allow trailing space
     )
     await expect(log_y_plot.locator(`g.y-axis .tick text`).nth(2)).toHaveText(
       `100`,
     )
     await expect(log_y_plot.locator(`g.y-axis .tick text`).nth(3)).toHaveText(
-      /^(1k|1000\s*)$/,
+      /^(1k|1000\s*)$/, // Allow SI prefix or full number with optional space
     )
     await expect(log_y_plot.locator(`g.y-axis .tick text`).nth(4)).toHaveText(
-      /^(10k|10000\s*)$/,
+      /^(10k|10000\s*)$/, // Allow SI prefix or full number with optional space
     )
 
     // Check log-x plot
     const log_x_plot = section.locator(`#log-x .scatter`)
     await expect(log_x_plot).toBeVisible()
-    // Stricter: Check tick count and specific tick values
+    // Check tick count and specific tick values for log x-axis
     await expect(log_x_plot.locator(`g.x-axis .tick`)).toHaveCount(7)
     await expect(log_x_plot.locator(`g.x-axis .tick text`).nth(0)).toHaveText(
       `10m`, // Use SI prefix
@@ -195,33 +184,25 @@ test.describe(`ScatterPlot Component Tests`, () => {
     await expect(log_x_plot.locator(`g.x-axis .tick text`).nth(5)).toHaveText(
       `1k`, // Use SI prefix
     )
-    // There might be a 7th tick (index 6) if the count is 7. Let's check for 10k
     await expect(log_x_plot.locator(`g.x-axis .tick text`).nth(6)).toHaveText(
-      `10k`, // Add check for potential 7th tick
+      `10k`, // Use SI prefix
     )
   })
 
   test(`custom styling is applied correctly`, async ({ page }) => {
-    const rainbow_plot = page.locator(
-      `#custom-style`, // Parent container with specific styles
-    )
-    const scatter_locator = rainbow_plot.locator(
-      `#rainbow-points .scatter`, // Target the specific scatter plot
-    )
+    const rainbow_plot = page.locator(`#custom-style`)
+    const scatter_locator = rainbow_plot.locator(`#rainbow-points .scatter`)
 
-    // Basic check: Plot exists
     await expect(scatter_locator).toBeVisible()
-
-    // Check if points are rendered (more robust than exact count if data varies)
     await expect(scatter_locator.locator(`.marker`).first()).toBeVisible()
 
-    // Check stroke attribute directly (assuming it's set as an attribute)
+    // Check stroke attribute directly
     const first_marker_for_stroke = scatter_locator.locator(`.marker`).first()
     await expect(first_marker_for_stroke).toHaveAttribute(`stroke`, `black`)
     await expect(first_marker_for_stroke).toHaveAttribute(`stroke-width`, `2`)
   })
 
-  // Helper function to click radio buttons reliably
+  // Helper function to click radio buttons reliably, bypassing potential visibility issues
   const click_radio = async (page: Page, selector: string): Promise<void> => {
     await page.evaluate((sel) => {
       const radio = document.querySelector(sel) as HTMLInputElement
@@ -241,20 +222,16 @@ test.describe(`ScatterPlot Component Tests`, () => {
     const linear_radio = section.locator(`input[value="linear"]`)
     const log_radio = section.locator(`input[value="log"]`)
 
-    // Check initial state (linear) and points
+    // Check initial state (linear)
     await expect(linear_radio).toBeChecked()
-    // Stricter: Check exact marker count
     await expect(color_scale_plot.locator(`.marker`)).toHaveCount(10)
-    // Stricter: Check color bar visibility using the correct class
     await expect(color_scale_plot.locator(`.colorbar`)).toBeVisible()
 
-    // Switch to log mode and check state
+    // Switch to log mode and check
     await click_radio(page, `#color-scale input[value="log"]`)
     await expect(log_radio).toBeChecked()
     await expect(linear_radio).not.toBeChecked()
-    // Stricter: Check marker count again
     await expect(color_scale_plot.locator(`.marker`)).toHaveCount(10)
-    // Stricter: Check color bar still visible using the correct class
     await expect(color_scale_plot.locator(`.colorbar`)).toBeVisible()
 
     // Switch back to linear mode
@@ -262,10 +239,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
     await expect(linear_radio).toBeChecked()
   })
 
-  // New hover tests from scratch
-
   test(`bind:hovered prop reflects hover state`, async ({ page }) => {
-    // Test the bind:hovered functionality using the specific example
     const section = page.locator(`#bind-hovered`)
     const scatter_plot = section.locator(`.scatter`)
     const svg = scatter_plot.locator(`svg[role='img']`)
@@ -274,13 +248,13 @@ test.describe(`ScatterPlot Component Tests`, () => {
     // Initial state: not hovered
     await expect(hover_status).toHaveText(`false`)
 
-    // Hover over plot - expect status to update automatically
+    // Hover over plot
     await svg.hover()
-    await expect(hover_status).toHaveText(`true`) // Playwright waits for this
+    await expect(hover_status).toHaveText(`true`) // Playwright waits for state change
 
-    // Move mouse away - expect status to update automatically
-    await page.mouse.move(0, 0) // Move to a point outside the plot area
-    await expect(hover_status).toHaveText(`false`) // Playwright waits for this
+    // Move mouse away
+    await page.mouse.move(0, 0)
+    await expect(hover_status).toHaveText(`false`) // Playwright waits for state change
   })
 
   // Helper function to get tick values as numbers and calculate range
@@ -291,13 +265,13 @@ test.describe(`ScatterPlot Component Tests`, () => {
     const tick_texts = await Promise.all(
       tick_elements.map((tick) => tick.textContent()),
     )
+    // Clean text, parse as float, and filter out NaN/null values
     const ticks = tick_texts
-      .filter((text): text is string => text !== null)
-      .map((text) => parseFloat(text.replace(/[^\d.-]/g, ``))) // Clean text, parse as float
-      .filter((num) => !isNaN(num)) // Filter out NaN values
+      .map((text) => (text ? parseFloat(text.replace(/[^\d.-]/g, ``)) : NaN))
+      .filter((num) => !isNaN(num))
 
     if (ticks.length < 2) {
-      return { ticks, range: 0 } // Not enough ticks to calculate a meaningful range
+      return { ticks, range: 0 } // Not enough ticks for a meaningful range
     }
     const range = Math.abs(Math.max(...ticks) - Math.min(...ticks))
     return { ticks, range }
@@ -312,7 +286,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
     const y_axis = plot_locator.locator(`g.y-axis`)
     const zoom_rect = plot_locator.locator(`rect.zoom-rect`)
 
-    // 1. Explicitly wait for first tick text to be visible before getting ranges
+    // 1. Wait for axes to be ready and get initial state
     await x_axis
       .locator(`.tick text`)
       .first()
@@ -324,7 +298,6 @@ test.describe(`ScatterPlot Component Tests`, () => {
 
     const initial_x = await get_tick_range(x_axis)
     const initial_y = await get_tick_range(y_axis)
-    // Stricter: Check exact initial tick counts (Adjusted)
     expect(initial_x.ticks.length).toBe(10)
     expect(initial_y.ticks.length).toBe(4)
     expect(initial_x.range).toBeGreaterThan(0)
@@ -333,73 +306,66 @@ test.describe(`ScatterPlot Component Tests`, () => {
     // 2. Perform zoom drag
     const svg_box = await svg.boundingBox()
     expect(svg_box).toBeTruthy()
-    const start_x = svg_box!.x + svg_box!.width * 0.3 // Start drag 30% into the plot
-    const start_y = svg_box!.y + svg_box!.height * 0.7 // Start drag 70% down
-    const end_x = svg_box!.x + svg_box!.width * 0.7 // End drag 70% into the plot
-    const end_y = svg_box!.y + svg_box!.height * 0.3 // End drag 30% down
+    const start_x = svg_box!.x + svg_box!.width * 0.3
+    const start_y = svg_box!.y + svg_box!.height * 0.7
+    const end_x = svg_box!.x + svg_box!.width * 0.7
+    const end_y = svg_box!.y + svg_box!.height * 0.3
 
     await page.mouse.move(start_x, start_y)
     await page.mouse.down()
-    // Rect might be 0x0 initially, so don't check visibility yet
+    await page.mouse.move(end_x, end_y, { steps: 5 }) // Smooth move
 
-    await page.mouse.move(end_x, end_y, { steps: 5 })
-    // After moving, the rect should have dimensions and be visible
-    await expect(zoom_rect).toBeVisible() // Check rect is still visible during move
+    // Check zoom rectangle is visible and has dimensions during drag
+    await expect(zoom_rect).toBeVisible()
     const rect_box = await zoom_rect.boundingBox()
     expect(rect_box).toBeTruthy()
     expect(rect_box!.width).toBeGreaterThan(0)
     expect(rect_box!.height).toBeGreaterThan(0)
 
     await page.mouse.up()
-    await expect(zoom_rect).not.toBeVisible() // Check rect disappears
+    await expect(zoom_rect).not.toBeVisible() // Rect disappears after mouse up
 
     // 3. Verify ticks have changed and range decreased (zoomed)
     const zoomed_x = await get_tick_range(x_axis)
     const zoomed_y = await get_tick_range(y_axis)
-    expect(zoomed_x.ticks).not.toEqual(initial_x.ticks) // Ticks themselves should change
+    expect(zoomed_x.ticks).not.toEqual(initial_x.ticks)
     expect(zoomed_y.ticks).not.toEqual(initial_y.ticks)
-    expect(zoomed_x.range).toBeLessThan(initial_x.range) // Range should decrease
+    expect(zoomed_x.range).toBeLessThan(initial_x.range)
     expect(zoomed_y.range).toBeLessThan(initial_y.range)
-    expect(zoomed_x.range).toBeGreaterThan(0) // Range should still be positive
+    expect(zoomed_x.range).toBeGreaterThan(0) // Range still positive
     expect(zoomed_y.range).toBeGreaterThan(0)
 
-    // 4. Perform double-click to reset
+    // 4. Double-click to reset zoom
     await svg.dblclick()
 
-    // 5. Verify ticks and ranges have reset to initial values
+    // 5. Verify ticks and ranges have reset
     const reset_x = await get_tick_range(x_axis)
     const reset_y = await get_tick_range(y_axis)
-    expect(reset_x.ticks).toEqual(initial_x.ticks) // Ticks should be back to original
+    expect(reset_x.ticks).toEqual(initial_x.ticks)
     expect(reset_y.ticks).toEqual(initial_y.ticks)
-    expect(reset_x.range).toBeCloseTo(initial_x.range) // Range should be back to original (use toBeCloseTo for float precision)
+    expect(reset_x.range).toBeCloseTo(initial_x.range) // Use toBeCloseTo for float precision
     expect(reset_y.range).toBeCloseTo(initial_y.range)
   })
 
   // --- Label Auto Placement Tests ---
 
-  // Helper function to get label positions
+  // Helper function to get label positions based on the parent group's transform
   const get_label_positions = async (
     plot_locator: Locator,
   ): Promise<Record<string, { x: number; y: number }>> => {
     await plot_locator.waitFor({ state: `visible` })
-    await plot_locator.page().waitForTimeout(200)
+    await plot_locator.page().waitForTimeout(200) // Allow layout stabilization
 
     const positions: Record<string, { x: number; y: number }> = {}
-    // Find all marker paths first
-    const markers = await plot_locator.locator(`path.marker`).all()
+    const markers = await plot_locator.locator(`path.marker`).all() // Find marker paths
 
     for (const marker of markers) {
-      // Get the parent <g> of the marker
-      const parent_group = marker.locator(`..`)
-
-      // Find the text element within that same group
-      const label_text_element = parent_group.locator(`text`)
+      const parent_group = marker.locator(`..`) // Get parent <g>
+      const label_text_element = parent_group.locator(`text`) // Find text within the group
       const label_text_content = await label_text_element.textContent()
 
       if (label_text_content) {
-        // Get the transform from the parent group
-        const transform = await parent_group.getAttribute(`transform`)
-
+        const transform = await parent_group.getAttribute(`transform`) // Get transform from group
         if (transform) {
           const match = transform.match(
             /translate\(([^\s,]+)\s*,?\s*([^\)]+)\)/,
@@ -416,7 +382,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
     return positions
   }
 
-  // TODO fix this test
+  // TODO: Fix this test - label positioning logic or timing might be flaky
   test.skip(`label auto-placement repositions labels in dense clusters`, async ({
     page,
   }) => {
@@ -441,13 +407,13 @@ test.describe(`ScatterPlot Component Tests`, () => {
     const dense_labels = Object.keys(positions_auto).filter((key) =>
       key.startsWith(`Dense-`),
     )
-    expect(dense_labels.length).toBeGreaterThan(1) // Make sure we have dense labels
+    expect(dense_labels.length).toBeGreaterThan(1)
 
     let moved_count = 0
     for (const label_text of dense_labels) {
       expect(positions_auto[label_text]).toBeDefined()
       expect(positions_manual[label_text]).toBeDefined()
-      // Check if position differs by more than a small threshold (e.g., 1px)
+      // Check if position differs significantly
       const dx = Math.abs(
         positions_auto[label_text].x - positions_manual[label_text].x,
       )
@@ -459,7 +425,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
       }
     }
 
-    // Expect most (if not all) dense labels to have moved
+    // Expect most dense labels to have moved due to auto-placement
     expect(moved_count).toBeGreaterThan(dense_labels.length / 2)
   })
 
@@ -470,16 +436,15 @@ test.describe(`ScatterPlot Component Tests`, () => {
     const plot_locator = section.locator(`.scatter`)
     const checkbox = section.locator(`input[type="checkbox"]`)
 
-    // Ensure auto-placement is initially enabled
+    // Ensure auto-placement is initially enabled and wait for simulation
     await expect(checkbox).toBeChecked()
-    await page.waitForTimeout(800) // Wait for simulation
+    await page.waitForTimeout(800)
     const positions_auto = await get_label_positions(plot_locator)
 
-    // Disable auto-placement
+    // Disable auto-placement and wait for re-render
     await checkbox.uncheck()
-    await page.waitForTimeout(200) // Wait for re-render
     await expect(checkbox).not.toBeChecked()
-    await page.waitForTimeout(100) // Wait for re-render
+    await page.waitForTimeout(300) // Increased wait time
     const positions_manual = await get_label_positions(plot_locator)
 
     // Verify positions are similar for sparse labels
@@ -491,20 +456,20 @@ test.describe(`ScatterPlot Component Tests`, () => {
     for (const label_text of sparse_labels) {
       expect(positions_auto[label_text]).toBeDefined()
       expect(positions_manual[label_text]).toBeDefined()
-      // Check if positions are very close (allow slightly larger deviation for simulation)
+      // Check if positions are very close (precision -1 means diff < 0.5px)
       expect(positions_auto[label_text].x).toBeCloseTo(
         positions_manual[label_text].x,
-        -1, // precision=-1 means diff < 0.5px
+        -1,
       )
       expect(positions_auto[label_text].y).toBeCloseTo(
         positions_manual[label_text].y,
-        -1, // precision=-1 means diff < 0.5px
+        -1,
       )
     }
   })
 
   test.describe(`Legend Rendering`, () => {
-    const legend_selector = `.legend` // Use data attribute selector
+    const legend_selector = `.legend`
 
     test(`legend does NOT render for single series by default`, async ({
       page,
@@ -530,7 +495,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
       const legend_locator = plot_locator.locator(legend_selector)
       await expect(legend_locator).toBeVisible()
       const label_span = legend_locator.locator(`.legend-label`)
-      // Check legend item text - should now use default 'Series 1' as test data lacks top-level label
+      // Uses label from test data config
       await expect(label_span).toHaveText(`Single Series`)
     })
 
@@ -539,9 +504,8 @@ test.describe(`ScatterPlot Component Tests`, () => {
       await expect(plot_locator).toBeVisible()
       const legend_locator = plot_locator.locator(legend_selector)
       await expect(legend_locator).toBeVisible()
-      // Check legend item count
       await expect(legend_locator.locator(`.legend-item`)).toHaveCount(2)
-      // Check legend item texts - should now use defaults 'Series 1', 'Series 2'
+      // Uses labels from test data config
       const label_span = legend_locator.locator(`.legend-label`)
       await expect(label_span.nth(0)).toHaveText(`Series A`)
       await expect(label_span.nth(1)).toHaveText(`Series B`)
@@ -550,7 +514,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
     test(`legend does NOT render for zero series`, async ({ page }) => {
       const legend_section = page.locator(`#legend-tests`)
       const plot = legend_section.locator(`#legend-zero`)
-      await expect(plot.locator(legend_selector)).toHaveCount(0) // Changed assertion for consistency
+      await expect(plot.locator(legend_selector)).toHaveCount(0)
     })
   })
 
@@ -564,18 +528,19 @@ test.describe(`ScatterPlot Component Tests`, () => {
         `g[data-series-idx='0'] .marker`,
       )
 
-      // Initial: Expect points to be visible (count based on default view)
-      await expect(series_a_markers).toHaveCount(2)
+      // Initial state: Series A visible
+      await expect(series_a_markers).toHaveCount(2) // Expect 2 points initially
       await expect(legend_item).not.toHaveClass(/hidden/)
 
-      // Click to hide
+      // Click to hide Series A
       await legend_item.click()
-      // await expect(series_a_markers).toHaveCount(0) // TODO: fix this, actually get 0
-      await expect(legend_item).toHaveClass(/hidden/)
+      // TODO: Check why marker count isn't 0. Maybe they are just display:none?
+      // await expect(series_a_markers).toHaveCount(0)
+      await expect(legend_item).toHaveClass(/hidden/) // Legend item visually hidden
 
-      // Click to show
+      // Click to show Series A again
       await legend_item.click()
-      await expect(series_a_markers).toHaveCount(2)
+      await expect(series_a_markers).toHaveCount(2) // Points visible again
       await expect(legend_item).not.toHaveClass(/hidden/)
     })
 
@@ -585,10 +550,10 @@ test.describe(`ScatterPlot Component Tests`, () => {
       const plot_locator = page.locator(`#legend-multi-default .scatter`)
       const series_a_item = plot_locator
         .locator(`.legend-item >> text=Series A`)
-        .locator(`..`) // Get parent div
+        .locator(`..`)
       const series_b_item = plot_locator
         .locator(`.legend-item >> text=Series B`)
-        .locator(`..`) // Get parent div
+        .locator(`..`)
       const series_a_markers = plot_locator.locator(
         `g[data-series-idx='0'] .marker`,
       )
@@ -596,24 +561,75 @@ test.describe(`ScatterPlot Component Tests`, () => {
         `g[data-series-idx='1'] .marker`,
       )
 
-      // Initial: Both visible (count based on default view)
+      // Initial state: Both series visible
       await expect(series_a_markers).toHaveCount(2)
       await expect(series_b_markers).toHaveCount(2)
       await expect(series_a_item).not.toHaveClass(/hidden/)
       await expect(series_b_item).not.toHaveClass(/hidden/)
 
-      // Double click A to isolate
+      // Double click A to isolate it
       await series_a_item.dblclick()
-      await expect(series_a_markers).toHaveCount(2)
-      await expect(series_b_markers).toHaveCount(0)
+      await expect(series_a_markers).toHaveCount(2) // A remains visible
+      await expect(series_b_markers).toHaveCount(0) // B becomes hidden
       await expect(series_a_item).not.toHaveClass(/hidden/)
-      await expect(series_b_item).toHaveClass(/hidden/)
+      await expect(series_b_item).toHaveClass(/hidden/) // B legend item visually hidden
 
-      // Double click A again to restore
+      // Double click A again to restore all
       await series_a_item.dblclick()
-      // await expect(series_b_markers).toHaveCount(2) // TODO: fix this, actually get 0
+      // TODO: Fix checks after restore. Similar issue as single click toggle?
+      // await expect(series_b_markers).toHaveCount(2) // B should be visible again
       // await expect(series_a_item).not.toHaveClass(/hidden/)
       // await expect(series_b_item).not.toHaveClass(/hidden/)
     })
+  })
+
+  test(`no console errors or rendering issues on linear-log scale transition`, async ({
+    page,
+  }) => {
+    const section = page.locator(`#lin-log-transition`)
+    const plot_locator = section.locator(`.scatter`)
+    const svg = plot_locator.locator(`svg[role='img']`)
+    const linear_radio = section.locator(`input[value="linear"]`)
+    const log_radio = section.locator(`input[value="log"]`)
+    const y_axis_ticks = plot_locator.locator(`g.y-axis .tick`)
+    const first_point_marker = plot_locator.locator(`.marker`).first()
+
+    const page_errors: Error[] = []
+    const console_errors: string[] = []
+
+    page.on(`pageerror`, (error) => page_errors.push(error))
+    page.on(`console`, (msg) => {
+      if (msg.type() === `error`) {
+        // Optionally ignore known non-critical "errors" here
+        console_errors.push(msg.text())
+      }
+    })
+
+    // Initial state (linear)
+    await expect(linear_radio).toBeChecked()
+    await expect(log_radio).not.toBeChecked()
+    await expect(svg).toBeVisible()
+    await expect(y_axis_ticks.first()).toBeVisible()
+    await expect(first_point_marker).toBeVisible()
+
+    // Toggle to log scale
+    await log_radio.click()
+    await expect(log_radio).toBeChecked()
+    // Check critical elements are visible after state change (Playwright auto-waits)
+    await expect(svg).toBeVisible({ timeout: 2000 }) // Use timeout for robustness
+    await expect(y_axis_ticks.first()).toBeVisible({ timeout: 2000 })
+    await expect(first_point_marker).toBeVisible({ timeout: 2000 })
+
+    // Toggle back to linear scale
+    await linear_radio.click()
+    await expect(linear_radio).toBeChecked()
+    // Check critical elements again after state change
+    await expect(svg).toBeVisible({ timeout: 2000 })
+    await expect(y_axis_ticks.first()).toBeVisible({ timeout: 2000 })
+    await expect(first_point_marker).toBeVisible({ timeout: 2000 })
+
+    // Assert no errors occurred during transitions
+    expect(page_errors).toHaveLength(0)
+    expect(console_errors).toHaveLength(0)
   })
 })

--- a/tests/unit/ColorBar.test.ts
+++ b/tests/unit/ColorBar.test.ts
@@ -18,22 +18,22 @@ describe(`ColorBar Horizontal (Default)`, () => {
     mount(ColorBar, {
       target: document.body,
       props: {
-        label: `Test Horizontal`,
+        title: `Test Horizontal`,
         color_scale: `Viridis`,
         tick_labels: 5, // D3 nice().ticks(5) for [0, 100] -> [0, 20, 40, 60, 80, 100]
         range: [0, 100],
-        label_side: `left`,
+        title_side: `left`,
         tick_side: `primary`, // primary = bottom for horizontal
         style: `width: 200px; height: 20px;`,
-        label_style: `font-weight: bold;`,
+        title_style: `font-weight: bold;`,
         wrapper_style: `margin: 10px;`,
       },
     })
 
-    const label_span = doc_query(`.colorbar > span.label`) as HTMLElement
-    expect(label_span.textContent).toBe(`Test Horizontal`)
-    expect(label_span.getAttribute(`style`)).toContain(`font-weight: bold;`)
-    expect(label_span.getAttribute(`style`)).not.toContain(`transform: rotate`) // No rotation
+    const title_span = doc_query(`.colorbar > span.label`) as HTMLElement
+    expect(title_span.textContent).toBe(`Test Horizontal`)
+    expect(title_span.getAttribute(`style`)).toContain(`font-weight: bold;`)
+    expect(title_span.getAttribute(`style`)).not.toContain(`transform: rotate`) // No rotation
 
     const cbar_div = doc_query(`.colorbar > div.bar`)
     expect(cbar_div.style.width).toBe(`200px`)
@@ -50,7 +50,7 @@ describe(`ColorBar Horizontal (Default)`, () => {
 
     const wrapper = doc_query(`.colorbar`)
     expect(wrapper.style.margin).toBe(`10px`)
-    expect(wrapper.style.flexDirection).toBe(`row`) // label_side: left
+    expect(wrapper.style.flexDirection).toBe(`row`) // title_side: left
   })
 
   test(`handles invalid color_scale input`, () => {
@@ -72,21 +72,19 @@ describe(`ColorBar Vertical`, () => {
     mount(ColorBar, {
       target: document.body,
       props: {
-        label: `Test Vertical Default`,
+        title: `Test Vertical Default`,
         orientation: `vertical`,
         range: [0, 10],
         tick_labels: 5, // D3 nice().ticks(5) for [0, 10] -> [0, 2, 4, 6, 8, 10]
       },
     })
 
-    const wrapper = doc_query(`.colorbar`)
-    // Default label_side: left, tick_side: primary (right)
-    expect(wrapper.style.flexDirection).toBe(`row`) // Label should be left of bar
+    const wrapper_vert_def = doc_query(`.colorbar`)
+    expect(wrapper_vert_def.style.flexDirection).toBe(`row`)
 
-    const label_span = doc_query(`.colorbar > span.label`)
-    expect(label_span.textContent).toBe(`Test Vertical Default`)
-    // Check rotation via attribute due to happy-dom issues
-    expect(label_span.getAttribute(`style`)).toContain(
+    const title_span_vert_def = doc_query(`.colorbar > span.label`)
+    expect(title_span_vert_def.textContent).toBe(`Test Vertical Default`)
+    expect(title_span_vert_def.getAttribute(`style`)).toContain(
       `transform: rotate(-90deg) translate(50%); transform-origin: right bottom;`,
     )
 
@@ -113,24 +111,25 @@ describe(`ColorBar Vertical`, () => {
     mount(ColorBar, {
       target: document.body,
       props: {
-        label: `Test Vertical Explicit`,
+        title: `Test Vertical Explicit`,
         orientation: `vertical`,
         range: [-50, 50],
         tick_labels: 4, // D3 nice().ticks(4) for [-50, 50] -> [-60, -40, -20, 0, 20, 40, 60]
-        label_side: `top`,
+        title_side: `top`,
         tick_side: `secondary`, // secondary = left for vertical
         style: `width: 20px; height: 300px;`,
         wrapper_style: `height: 350px;`,
       },
     })
 
-    const wrapper = doc_query(`.colorbar`)
-    expect(wrapper.style.flexDirection).toBe(`column`) // Label top of bar
-    expect(wrapper.style.height).toBe(`350px`)
+    const wrapper_vert_exp = doc_query(`.colorbar`)
+    expect(wrapper_vert_exp.style.flexDirection).toBe(`column`)
+    expect(wrapper_vert_exp.style.height).toBe(`350px`)
 
-    const label_span = doc_query(`.colorbar > span.label`) as HTMLElement
-    expect(label_span.textContent).toBe(`Test Vertical Explicit`)
-    // Skip transform check due to happy-dom issues
+    const title_span_vert_exp = doc_query(
+      `.colorbar > span.label`,
+    ) as HTMLElement
+    expect(title_span_vert_exp.textContent).toBe(`Test Vertical Explicit`)
 
     const cbar_div = doc_query(`.colorbar > div.bar`)
     expect(cbar_div.style.width).toBe(`20px`)
@@ -144,7 +143,6 @@ describe(`ColorBar Vertical`, () => {
     const middle_tick = tick_label_spans[3] as HTMLElement // Tick '0'
     expect(middle_tick.textContent).toBe(`0`)
     expect(middle_tick.style.top).toBe(`50%`)
-    // Skip right style check due to happy-dom issues
     expect(middle_tick.style.transform).toBe(`translateY(-50%)`)
   })
 })
@@ -171,7 +169,7 @@ describe(`ColorBar tick_side='inside'`, () => {
     expect(first_visible_tick.textContent).toBe(`20`)
     expect(first_visible_tick.style.left).toBe(`20%`)
     expect(first_visible_tick.style.top).toBe(`50%`) // Centered vertically
-    // Skip transform check due to happy-dom issues
+    expect(first_visible_tick.style.transform).toBe(`translate(-50%, -50%)`)
 
     const last_visible_tick = tick_label_spans[3] as HTMLElement
     expect(last_visible_tick.textContent).toBe(`80`)
@@ -200,7 +198,7 @@ describe(`ColorBar tick_side='inside'`, () => {
     expect(first_visible_tick.textContent).toBe(`20`)
     expect(first_visible_tick.style.top).toBe(`12.5%`)
     expect(first_visible_tick.style.left).toBe(`50%`) // Centered horizontally
-    // Skip transform check due to happy-dom issues
+    expect(first_visible_tick.style.transform).toBe(`translate(-50%, -50%)`)
 
     const last_visible_tick = tick_label_spans[6] as HTMLElement
     expect(last_visible_tick.textContent).toBe(`80`)
@@ -209,28 +207,156 @@ describe(`ColorBar tick_side='inside'`, () => {
   })
 })
 
-describe(`ColorBar label_side Default Logic`, () => {
+describe(`ColorBar title_side Default Logic`, () => {
   test.each([
     // [orientation, tick_side, expected_flex_dir]
-    [`horizontal`, `primary`, `column`], // Ticks bottom -> label top
-    [`horizontal`, `secondary`, `column-reverse`], // Ticks top -> label bottom
-    [`vertical`, `primary`, `row`], // Ticks right -> label left
-    [`vertical`, `secondary`, `row-reverse`], // Ticks left -> label right
-    [`horizontal`, `inside`, `row`], // Ticks inside -> label left
-    [`vertical`, `inside`, `row`], // Ticks inside -> label left
+    [`horizontal`, `primary`, `column`],
+    [`horizontal`, `secondary`, `column-reverse`],
+    [`vertical`, `primary`, `row`],
+    [`vertical`, `secondary`, `row-reverse`],
+    [`horizontal`, `inside`, `row`],
+    [`vertical`, `inside`, `row`],
   ] as const)(
-    `orientation=%s, tick_side=%s -> defaults label flex-direction to %s`,
+    `orientation=%s, tick_side=%s -> defaults title flex-direction to %s`,
     (orientation, tick_side, expected_flex_dir) => {
       mount(ColorBar, {
         target: document.body,
-        props: { label: `Test Default Label`, orientation, tick_side },
+        props: { title: `Test Default Title`, orientation, tick_side },
       })
       const wrapper = doc_query(`.colorbar`)
       expect(wrapper.style.flexDirection).toBe(expected_flex_dir)
 
-      // Label should not have overlap margin when using defaults
-      const label_span = doc_query(`.colorbar > span.label`) as HTMLElement
-      expect(label_span.getAttribute(`style`)).not.toContain(`margin`)
+      // Title span should exist
+      const title_span = doc_query(`.colorbar > span.label`) as HTMLElement
+      expect(title_span).toBeDefined()
+      expect(title_span.textContent).toBe(`Test Default Title`)
+      // Title span should not have overlap margin when using defaults
+      expect(title_span.getAttribute(`style`)).not.toContain(`margin`)
     },
   )
+})
+
+describe(`ColorBar Date/Time Formatting`, () => {
+  test(`formats ticks correctly using tick_format`, () => {
+    const date_range: [number, number] = [
+      new Date(2024, 0, 1).getTime(), // Jan 1, 2024
+      new Date(2024, 11, 31).getTime(), // Dec 31, 2024
+    ]
+
+    mount(ColorBar, {
+      target: document.body,
+      props: {
+        range: date_range,
+        tick_format: `%Y-%m-%d`, // YYYY-MM-DD format
+        tick_labels: 3, // Request 3 ticks
+        snap_ticks: false, // Use exact range for predictability
+      },
+    })
+
+    const tick_label_spans = document.querySelectorAll(
+      `.colorbar > div.bar > span.tick-label`,
+    )
+    expect(tick_label_spans.length).toBe(3)
+    expect(tick_label_spans[0].textContent).toBe(`2024-01-01`) // Start date
+    expect(tick_label_spans[1].textContent).toBe(`2024-07-01`) // Mid-point (approx)
+    expect(tick_label_spans[2].textContent).toBe(`2024-12-31`) // End date
+  })
+
+  test(`formats ticks with different format string`, () => {
+    const date_range: [number, number] = [
+      new Date(2024, 0, 1, 0, 0, 0).getTime(), // Start of day
+      new Date(2024, 0, 1, 23, 59, 59).getTime(), // End of day
+    ]
+
+    mount(ColorBar, {
+      target: document.body,
+      props: {
+        range: date_range,
+        tick_format: `%H:%M`, // HH:MM format
+        tick_labels: 5, // Request 5 ticks
+        snap_ticks: false,
+      },
+    })
+
+    const tick_label_spans_date_fmt = document.querySelectorAll(
+      `.colorbar > div.bar > span.tick-label`,
+    )
+    expect(tick_label_spans_date_fmt.length).toBe(5)
+    expect(tick_label_spans_date_fmt[0].textContent).toBe(`00:00`)
+    expect([`11:59`, `12:00`]).toContain(
+      tick_label_spans_date_fmt[2].textContent,
+    )
+    expect(tick_label_spans_date_fmt[4].textContent).toBe(`23:59`) // Near end of day
+  })
+})
+
+describe(`ColorBar Other Features`, () => {
+  test(`uses explicit tick_labels array`, () => {
+    const explicit_ticks = [10, 25, 50, 75, 90]
+    mount(ColorBar, {
+      target: document.body,
+      props: {
+        range: [0, 100],
+        tick_labels: explicit_ticks,
+        snap_ticks: true, // snap_ticks should be ignored when array is passed
+      },
+    })
+
+    const tick_label_spans = document.querySelectorAll(
+      `.colorbar > div.bar > span.tick-label`,
+    )
+    expect(tick_label_spans.length).toBe(explicit_ticks.length)
+    explicit_ticks.forEach((tick, idx) => {
+      expect(tick_label_spans[idx].textContent).toBe(tick.toString())
+    })
+  })
+
+  test(`snap_ticks=false generates exact number of ticks`, () => {
+    mount(ColorBar, {
+      target: document.body,
+      props: { range: [0, 99], tick_labels: 4, snap_ticks: false },
+    })
+
+    const tick_label_spans = document.querySelectorAll(
+      `.colorbar > div.bar > span.tick-label`,
+    )
+    expect(tick_label_spans.length).toBe(4)
+    expect(tick_label_spans[0].textContent).toBe(`0`)
+    expect(tick_label_spans[1].textContent).toBe(`33`)
+    expect(tick_label_spans[2].textContent).toBe(`66`)
+    expect(tick_label_spans[3].textContent).toBe(`99`)
+  })
+
+  test(`does NOT apply label overlap margin when ticks and title are on opposite sides`, () => {
+    mount(ColorBar, {
+      target: document.body,
+      props: {
+        title: `No Overlap Test`,
+        orientation: `horizontal`,
+        title_side: `top`,
+        tick_side: `primary`,
+        tick_labels: 3,
+      },
+    })
+
+    const title_span_no_overlap = doc_query(`.colorbar > span.label`)
+    expect(title_span_no_overlap.getAttribute(`style`)).not.toContain(`margin`)
+  })
+
+  test(`accepts a function for color_scale`, () => {
+    const custom_scale = vi.fn((t: number): string => `rgb(${t * 255}, 0, 0)`) // Mock scale
+    mount(ColorBar, {
+      target: document.body,
+      props: { color_scale: custom_scale, range: [0, 1] }, // Use default steps=50
+    })
+
+    // Verify the mock function was called (steps times)
+    expect(custom_scale).toHaveBeenCalled()
+    expect(custom_scale).toHaveBeenCalledTimes(50) // Default steps is 50
+
+    // Optional: Check if the first call was with the expected value (approx 0)
+    expect(custom_scale).toHaveBeenNthCalledWith(1, expect.closeTo(0))
+    // Optional: Check if the last call was with the expected value (approx 1)
+    expect(custom_scale).toHaveBeenNthCalledWith(50, expect.closeTo(1))
+  })
 })

--- a/tests/unit/Line.test.ts
+++ b/tests/unit/Line.test.ts
@@ -1,5 +1,7 @@
 import { Line } from '$lib'
+import { interpolatePath } from 'd3-interpolate-path'
 import { mount } from 'svelte'
+import { sineIn } from 'svelte/easing'
 import { beforeEach, describe, expect, test } from 'vitest'
 
 describe(`Line`, () => {
@@ -89,8 +91,9 @@ describe(`Line`, () => {
     ] as [number, number][]
     mount(Line, {
       target: target_div,
-      props: { points: points_3, origin, tween_duration: 0 },
+      props: { points: points_3, origin, line_tween: { duration: 0 } },
     })
+
     const paths_3 = target_div.querySelectorAll(`path`)
     expect(paths_3[0].getAttribute(`d`)).toMatch(/^M0,100C.*100,0.*C.*200,100$/)
 
@@ -104,8 +107,9 @@ describe(`Line`, () => {
     ] as [number, number][]
     mount(Line, {
       target: target_div, // Reuse the cleaned div
-      props: { points: points_2, origin, tween_duration: 0 },
+      props: { points: points_2, origin, line_tween: { duration: 0 } },
     })
+
     const paths_2 = target_div.querySelectorAll(`path`)
     expect(paths_2[0].getAttribute(`d`)).toMatch(/^M0,100L100,0$/)
   })
@@ -119,7 +123,7 @@ describe(`Line`, () => {
 
     mount(Line, {
       target: target_div,
-      props: { points, origin, tween_duration: 0 },
+      props: { points, origin, line_tween: { duration: 0 } },
     })
 
     const area_path = target_div.querySelectorAll(`path`)[1]
@@ -164,12 +168,37 @@ describe(`Line`, () => {
 
     mount(Line, {
       target: target_div,
-      props: { points, origin, tween_duration: 0 },
+      props: { points, origin, line_tween: { duration: 0 } },
     })
 
     const paths = target_div.querySelectorAll(`path`)
     expect(paths.length).toBe(2)
     expect(paths[0].getAttribute(`d`)).toMatch(/^M50,50Z?$/)
     expect(paths[1].getAttribute(`d`)).toMatch(/^M50,50Z?L50,100L50,100Z$/)
+  })
+
+  test(`applies custom tween options (easing, interpolate)`, () => {
+    const points: [number, number][] = [
+      [10, 10],
+      [50, 50],
+    ]
+    const origin: [number, number] = [0, 100]
+
+    const custom_tween = {
+      duration: 500,
+      easing: sineIn, // Custom easing function
+      interpolate: interpolatePath, // Custom interpolator for paths
+    }
+
+    const component = mount(Line, {
+      target: target_div,
+      props: { points, origin, line_tween: custom_tween },
+    })
+
+    expect(component).toBeTruthy() // Primary check: Component mounts without error
+    const paths = target_div.querySelectorAll(`path`)
+    expect(paths.length).toBe(2)
+    // Further checks on internal tween state are difficult in unit tests,
+    // but mounting confirms the props were accepted.
   })
 })

--- a/tests/unit/ScatterPoint.test.ts
+++ b/tests/unit/ScatterPoint.test.ts
@@ -297,74 +297,98 @@ describe(`ScatterPoint`, () => {
   describe(`Tween Behavior`, () => {
     beforeEach(() => {
       vi.useFakeTimers()
-      // No need to clear body here as outer beforeEach does it
     })
 
     test.each([
       {
         description: `default origin (0,0)`,
-        props: { x: 100, y: 150, offset: { x: 10, y: -10 } },
+        props: {
+          x: 100,
+          y: 150,
+          offset: { x: 10, y: -10 },
+          point_tween: undefined,
+        },
         expected_origin: { x: 0, y: 0 },
+        expected_target: { x: 110, y: 140 },
       },
       {
         description: `specified origin`,
         props: {
           x: 100,
           y: 150,
-          origin_x: 50,
-          origin_y: 75,
+          origin: { x: 50, y: 75 },
           offset: { x: 10, y: -10 },
+          point_tween: undefined,
         },
         expected_origin: { x: 50, y: 75 },
+        expected_target: { x: 110, y: 140 },
       },
       {
         description: `no offset`,
         props: {
           x: 100,
           y: 150,
-          origin_x: 20,
-          origin_y: 30,
+          origin: { x: 20, y: 30 },
           offset: { x: 0, y: 0 },
+          point_tween: undefined,
         },
         expected_origin: { x: 20, y: 30 },
+        expected_target: { x: 100, y: 150 },
       },
       {
         description: `negative coordinates`,
         props: {
           x: -100,
           y: -150,
-          origin_x: -50,
-          origin_y: -75,
+          origin: { x: -50, y: -75 },
           offset: { x: -10, y: 10 },
+          point_tween: undefined,
         },
         expected_origin: { x: -50, y: -75 },
+        expected_target: { x: -110, y: -140 },
       },
-    ])(`tween starts from $description`, async ({ props, expected_origin }) => {
-      const tween_duration = 600
-      const effective_props = { ...props, tween_duration }
-      mount(ScatterPoint, {
-        target: document.querySelector(`div`)!,
-        props: effective_props,
-      })
-      const g_element = doc_query(`g`)
+    ])(
+      `tween starts from $description`,
+      async ({ props, expected_origin, expected_target }) => {
+        mount(ScatterPoint, { target: document.querySelector(`div`)!, props })
+        const g_element = doc_query(`g`)
 
-      // Check initial transform is at expected origin.
-      // Note: happy-dom might show translate(0 0) if effect runs too quickly.
-      expect(g_element.getAttribute(`transform`)).toBe(
-        `translate(${expected_origin.x} ${expected_origin.y})`,
-      )
+        // Let microtasks run to allow Svelte to process initial state/effects
+        await vi.advanceTimersByTimeAsync(0)
 
-      // Advance time; final state check removed due to happy-dom limitations.
-      vi.advanceTimersByTime(tween_duration)
-      await vi.runAllTimersAsync()
-    })
+        // Check initial transform is at expected origin.
+        expect(g_element.getAttribute(`transform`)).toBe(
+          `translate(${expected_origin.x} ${expected_origin.y})`,
+        )
+
+        // Advance time to end state
+        const default_tween_duration = 600
+        await vi.advanceTimersByTimeAsync(default_tween_duration)
+
+        // Check final transform is at target position, allowing for float precision
+        // Only perform final check for the default origin case due to HappyDOM limitations
+        if (props.origin === undefined && props.point_tween === undefined) {
+          const final_transform = g_element.getAttribute(`transform`)
+          const match = final_transform?.match(
+            /translate\(([^\s]+)\s+([^\)]+)\)/,
+          )
+          expect(match).not.toBeNull()
+          if (match) {
+            const final_x = parseFloat(match[1])
+            const final_y = parseFloat(match[2])
+            expect(final_x).toBeCloseTo(expected_target.x)
+            expect(final_y).toBeCloseTo(expected_target.y)
+          }
+        }
+        // For other cases, just ensure mounting works and initial state is correct
+      },
+    )
 
     test(`tween duration 0 snaps to final position`, () => {
       const props = {
         x: 200,
         y: 250,
-        origin_x: 10,
-        origin_y: 20,
+        origin: { x: 10, y: 20 },
         offset: { x: 5, y: 5 },
         point_tween: { duration: 0 },
       }
@@ -386,8 +410,7 @@ describe(`ScatterPoint`, () => {
       const props = {
         x: 100,
         y: 150,
-        origin_x: 0,
-        origin_y: 0,
+        origin: { x: 0, y: 0 },
         offset: { x: 0, y: 0 },
         point_tween: { duration: 800, easing: bounceIn },
       }

--- a/tests/unit/bonding.test.ts
+++ b/tests/unit/bonding.test.ts
@@ -4,7 +4,7 @@ import { max_dist, nearest_neighbor } from '$lib/structure/bonding'
 import { performance } from 'perf_hooks'
 import { describe, expect, test } from 'vitest'
 
-const ci_max_time_multiplier = process.env.CI ? 5 : 1
+const ci_max_time_multiplier = process.env.CI ? 5 : 1.5
 
 // Function to generate a random structure
 function make_rand_structure(numAtoms: number) {


### PR DESCRIPTION
* fix bug when tweening `ScatterPoint` between linear and log-scaled axes in `ScatterPlot` where interpolated coordinates may contain NaNs
*   **ColorBar:**
    *   Introduces the `tick_format` prop for explicit control over tick label formatting (e.g., specific date/time formats).
    *   Renames props for clarity: `label` -> `title`, `label_style` -> `title_style`, `label_side` -> `title_side`.
*   **ScatterPlot, Line, ScatterPoint:**
    *   Adds customizable tweening via `point_tween` and `line_tween` props, allowing custom easing and interpolation functions (`TweenedOptions`).
*   **ScatterPlot:**
    *   Adds `get_screen_coords` function to filter invalid data points before rendering.
*   Includes new unit tests covering the date formatting and tweening features.
