### PR TITLE
Fix ScatterPlot zoom

### DIFF
--- a/src/lib/BohrAtom.svelte
+++ b/src/lib/BohrAtom.svelte
@@ -82,7 +82,7 @@
   {/if}
 
   <!-- electron orbitals -->
-  {#each shells as electrons, shell_idx (`${electrons}-${shell_idx}`)}
+  {#each shells as electrons, shell_idx ([electrons, shell_idx])}
     {@const n = shell_idx + 1}
     {@const shell_radius = _nucleus_props.r + n * shell_width}
     {@const active = n === highlight_shell}

--- a/src/lib/plot/ColorBar.svelte
+++ b/src/lib/plot/ColorBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { pretty_num } from '$lib'
+  import { format } from 'd3-format'
   import * as d3 from 'd3-scale'
   import * as d3_sc from 'd3-scale-chromatic'
   import { timeFormat } from 'd3-time-format'
@@ -255,9 +256,15 @@
       `}
 
       <span style={tick_inline_style} class="tick-label">
-        {tick_format
-          ? timeFormat(tick_format)(new Date(tick_label))
-          : pretty_num(tick_label)}
+        {#if tick_format}
+          {#if tick_format.startsWith(`%`)}
+            {timeFormat(tick_format)(new Date(tick_label))}
+          {:else}
+            {format(tick_format)(tick_label)}
+          {/if}
+        {:else}
+          {pretty_num(tick_label)}
+        {/if}
       </span>
     {/each}
   </div>

--- a/src/lib/plot/index.ts
+++ b/src/lib/plot/index.ts
@@ -88,7 +88,6 @@ export interface DataSeries {
 export interface InternalPoint extends PlotPoint {
   series_idx: number // Index of the series this point belongs to
   point_idx: number // Index of the point within its series
-  // Inherits all properties from PlotPoint
 }
 
 export type TooltipProps = {
@@ -158,3 +157,26 @@ export type LegendConfig = Omit<
 
 // Define Sides locally if not exported from $lib/colors
 export type Sides = { t?: number; b?: number; l?: number; r?: number }
+
+// Define grid cell identifiers
+export const cells_3x3 = [
+  `top-left`,
+  `top-center`,
+  `top-right`,
+  `middle-left`,
+  `middle-center`,
+  `middle-right`,
+  `bottom-left`,
+  `bottom-center`,
+  `bottom-right`,
+] as const
+export const corner_cells = [
+  `top-left`,
+  `top-right`,
+  `bottom-left`,
+  `bottom-right`,
+] as const
+
+// Define the structure for GridCell and GridCellCounts for 3x3 grid
+export type Cell3x3 = (typeof cells_3x3)[number]
+export type Corner = (typeof corner_cells)[number]

--- a/src/lib/plot/index.ts
+++ b/src/lib/plot/index.ts
@@ -128,6 +128,7 @@ export interface LabelPlacementConfig {
   link_strength: number // Strength of the link force (pulls label to point)
   link_distance: number // Target distance for the link force
   placement_ticks: number // Number of simulation ticks to run
+  link_distance_range?: [number | null, number | null] // Optional [min, max] range for distance between label and anchor
 }
 export type HoverConfig = {
   threshold_px: number // Max screen distance (pixels) to trigger hover

--- a/src/routes/(demos)/color-bar/+page.md
+++ b/src/routes/(demos)/color-bar/+page.md
@@ -5,26 +5,24 @@ Here's a `ColorBar` with tick labels, using the new `tick_align` prop:
 ```svelte example stackblitz
 <script>
   import { ColorBar } from '$lib'
-
-  const bars = [
-    // [color_scale, tick_align, tick_labels, range, label_text]
-    [`Viridis`, `primary`, [0, 0.25, 0.5, 0.75, 1], [0, 1], `bottom/right (primary)`],
-    [`Magma`, `secondary`, [], [100, 1631], `top/left (secondary)`],
-    [`Cividis`, `primary`, [], [-99.9812, -10], `bottom/right (primary)`],
-  ]
 </script>
 
 <div style="border: 0.1px dashed white;">
-  {#each bars as [color_scale, tick_align, tick_labels, range, align_desc]}
+  {#each [
+    // [color_scale, tick_align, tick_labels, range, label_text]
+    [`Viridis`, `primary`, [0, 0.25, 0.5, 0.75, 1], [0, 1]],
+    [`Magma`, `secondary`, 10, [100, 1631]],
+    [`Cividis`, `primary`, 4, [-99.9812, -10]],
+  ] as [color_scale, tick_align, tick_labels, range]}
     <ColorBar
-      title="{color_scale}<br>&bull; tick align={align_desc}<br>&bull; range={range}"
+      title="color_scale={color_scale} &emsp; tick_align={tick_align} &emsp; range={range}"
       {color_scale}
       {tick_align}
       {tick_labels}
       {range}
-      title_style="white-space: nowrap; padding-right: 1em;"
-      --cbar-width="100%"
-      --cbar-padding="2em"
+      tick_format=".2f"
+      title_style="padding: 1em;"
+      --cbar-padding="3em"
     />
   {/each}
 </div>

--- a/src/routes/(demos)/scatter-plot/+page.md
+++ b/src/routes/(demos)/scatter-plot/+page.md
@@ -1033,7 +1033,14 @@ This example demonstrates how the color bar automatically positions itself in on
   <div style="display: grid; grid-template-columns: repeat(2, max-content); gap: 1.5em; place-items: center; place-content: center;">
     {#each [['top_left', 'Top Left'], ['top_right', 'Top Right'], ['bottom_left', 'Bottom Left'], ['bottom_right', 'Bottom Right']] as [quadrant, label]}
       <label>{label}: {density[quadrant]}
-        <input type="range" min="0" max="100" bind:value={density[quadrant]} style="width: 100px; margin-left: 0.5em;" />
+        <input
+          type="range"
+          min="0"
+          max="100"
+          value={density[quadrant]}
+          onchange={(evt) => (density[quadrant] = evt.target.value)}
+          style="width: 100px; margin-left: 0.5em;"
+        />
       </label>
     {/each}
   </div>

--- a/src/routes/(demos)/scatter-plot/+page.md
+++ b/src/routes/(demos)/scatter-plot/+page.md
@@ -1029,7 +1029,7 @@ This example demonstrates how the color bar automatically positions itself in on
   })
 </script>
 
-<div>
+<div id="auto-colorbar-placement">
   <div style="display: grid; grid-template-columns: repeat(2, max-content); gap: 1.5em; place-items: center; place-content: center;">
     {#each [['top_left', 'Top Left'], ['top_right', 'Top Right'], ['bottom_left', 'Bottom Left'], ['bottom_right', 'Bottom Right']] as [quadrant, label]}
       <label>{label}: {density[quadrant]}
@@ -1053,7 +1053,7 @@ This example demonstrates how the color bar automatically positions itself in on
     y_lim={[0, 100]}
     markers="points+text"
     color_scheme="turbo"
-    color_bar={{ label: `Color Bar Title` }}
+    color_bar={{ title: `Color Bar Title`, margin: { t: 20, r: 60, b: 90, l: 80 } }}
     style="height: 450px; width: 100%;"
   >
     {#snippet tooltip({ x, y, metadata, color_value })}
@@ -1217,8 +1217,8 @@ This example shows how to place the color bar vertically on the right side of th
     {color_scale_type}
     padding={plot_padding}
     color_bar={{
+      title: `Color Bar Title (${color_scale_type})`,
       orientation: `vertical`,
-      label: `Color Bar Title (${color_scale_type})`,
       tick_side: `primary`,
       wrapper_style: `
         position: absolute;

--- a/tests/unit/ColorBar.test.ts
+++ b/tests/unit/ColorBar.test.ts
@@ -290,6 +290,93 @@ describe(`ColorBar Date/Time Formatting`, () => {
   })
 })
 
+describe(`ColorBar Numeric Formatting`, () => {
+  test(`formats ticks correctly using numeric d3-format (e.g., '.1f')`, () => {
+    mount(ColorBar, {
+      target: document.body,
+      props: {
+        range: [0, 10],
+        tick_format: `.1f`, // Format to one decimal place
+        tick_labels: 6, // Request 6 ticks (0, 2, 4, 6, 8, 10)
+        snap_ticks: true, // Use nice range
+      },
+    })
+
+    const tick_label_spans = document.querySelectorAll(
+      `.colorbar > div.bar > span.tick-label`,
+    )
+    expect(tick_label_spans.length).toBe(6)
+    expect(tick_label_spans[0].textContent).toBe(`0.0`)
+    expect(tick_label_spans[1].textContent).toBe(`2.0`)
+    expect(tick_label_spans[2].textContent).toBe(`4.0`)
+    expect(tick_label_spans[3].textContent).toBe(`6.0`)
+    expect(tick_label_spans[4].textContent).toBe(`8.0`)
+    expect(tick_label_spans[5].textContent).toBe(`10.0`)
+  })
+
+  test(`formats ticks with percentage format ('p')`, () => {
+    mount(ColorBar, {
+      target: document.body,
+      props: {
+        range: [0, 1],
+        tick_format: `.0%`, // Format as percentage with no decimals
+        tick_labels: 5, // Request 5 ticks (0, 0.25, 0.5, 0.75, 1)
+        snap_ticks: false, // Use exact range
+      },
+    })
+
+    const tick_label_spans = document.querySelectorAll(
+      `.colorbar > div.bar > span.tick-label`,
+    )
+    expect(tick_label_spans.length).toBe(5)
+    expect(tick_label_spans[0].textContent).toBe(`0%`)
+    expect(tick_label_spans[1].textContent).toBe(`25%`)
+    expect(tick_label_spans[2].textContent).toBe(`50%`)
+    expect(tick_label_spans[3].textContent).toBe(`75%`)
+    expect(tick_label_spans[4].textContent).toBe(`100%`)
+  })
+
+  test(`falls back to pretty_num when tick_format is undefined`, () => {
+    mount(ColorBar, {
+      target: document.body,
+      props: {
+        range: [0.1234, 5.6789],
+        tick_format: undefined, // Explicitly undefined
+        tick_labels: 3,
+        snap_ticks: false,
+      },
+    })
+
+    const tick_label_spans = document.querySelectorAll(
+      `.colorbar > div.bar > span.tick-label`,
+    )
+    expect(tick_label_spans.length).toBe(3)
+    // Check pretty_num's formatting
+    expect(tick_label_spans[0].textContent).toBe(`0.123`)
+    expect(tick_label_spans[1].textContent).toBe(`2.9`)
+    expect(tick_label_spans[2].textContent).toBe(`5.68`)
+  })
+
+  test(`falls back to pretty_num when tick_format is null`, () => {
+    // Test with null (should behave same as undefined)
+    mount(ColorBar, {
+      target: document.body,
+      props: {
+        range: [1000, 5000],
+        tick_format: undefined, // Use undefined as null is not assignable
+        tick_labels: 2,
+        snap_ticks: false,
+      },
+    })
+    const tick_label_spans = document.querySelectorAll(
+      `.colorbar > div.bar > span.tick-label`,
+    )
+    expect(tick_label_spans.length).toBe(2) // Should be 2 ticks
+    expect(tick_label_spans[0].textContent).toBe(`1k`) // Assuming pretty_num uses 'k' suffix
+    expect(tick_label_spans[1].textContent).toBe(`5k`)
+  })
+})
+
 describe(`ColorBar Other Features`, () => {
   test(`uses explicit tick_labels array`, () => {
     const explicit_ticks = [10, 25, 50, 75, 90]


### PR DESCRIPTION
- points were changing color when zooming into subset of points when colored by numerical scale
- xoom was ending prematurely when dragging outside plot area
- finer resolution (3x3 grid instead of 2x2) in `ScatterPlot` automatic color bar placement based on point density
- fix `ColorBar.svelte` always using d3.timeFormat when passed tick_format